### PR TITLE
Remove "brand new" phrasing from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 [![Build Status](https://travis-ci.org/laminas/laminas-mvc.svg?branch=master)](https://travis-ci.org/laminas/laminas-mvc)
 [![Coverage Status](https://coveralls.io/repos/github/laminas/laminas-mvc/badge.svg?branch=master)](https://coveralls.io/github/laminas/laminas-mvc?branch=master)
 
-`Laminas\Mvc` is a brand new MVC implementation designed from the ground up for
-Laminas, focusing on performance and flexibility.
+`Laminas\Mvc` is an MVC implementation focusing on performance and flexibility.
 
 The MVC layer is built on top of the following components:
 


### PR DESCRIPTION
|    Q        |   A
|------------ | ------
| Documentation      | yes
| Bugfix      | no
| BC Break    | no
| New Feature | no
| RFC         | no

### Description

We should not be signalling that Laminas\Mvc is brand new, especially with the new Laminas name  as this we're in danger of implying that this component is an all new component.

