### PR TITLE
Fix a broken link to an article on circlical.com

### DIFF
--- a/docs/book/cookbook/automating-controller-factories.md
+++ b/docs/book/cookbook/automating-controller-factories.md
@@ -61,4 +61,4 @@ factory, as reflection can introduce performance overhead.
 
 ## References
 
-This feature was inspired by [a blog post by Alexandre Lemaire](http://circlical.com/blog/2016/3/9/preparing-for-laminas-f).
+This feature was inspired by [a blog post by Alexandre Lemaire](http://circlical.com/blog/2016/3/9/preparing-for-zend-f).


### PR DESCRIPTION
The link (http://circlical.com/blog/2016/3/9/preparing-for-zend-f) contained “zend”, which was replaced with “laminas” in 7d7f3400f2bcb5a310db7a6d3304741ed4b6427f.

Signed-off-by: Grzegorz Szymaszek <gszymaszek@short.pl>