### PR TITLE
normalizing the responses of the methods

### DIFF
--- a/src/Controller/AbstractRestfulController.php
+++ b/src/Controller/AbstractRestfulController.php
@@ -361,25 +361,29 @@ abstract class AbstractRestfulController extends AbstractController
 
                 if ($id !== false) {
                     $action = 'delete';
-                    $return = $this->delete($id);
+                    $this->delete($id);
+                    $return = $e->getResponse();
                     break;
                 }
 
                 $data = $this->processBodyContent($request);
 
                 $action = 'deleteList';
-                $return = $this->deleteList($data);
+                $this->deleteList($data);
+                $return = $e->getResponse();
                 break;
             // GET
             case 'get':
                 $id = $this->getIdentifier($routeMatch, $request);
                 if ($id !== false) {
                     $action = 'get';
-                    $return = $this->get($id);
+                    $this->get($id);
+                    $return = $e->getResponse();
                     break;
                 }
                 $action = 'getList';
-                $return = $this->getList();
+                $this->getList();
+                $return = $e->getResponse();
                 break;
             // HEAD
             case 'head':
@@ -406,7 +410,8 @@ abstract class AbstractRestfulController extends AbstractController
 
                 if ($id !== false) {
                     $action = 'patch';
-                    $return = $this->patch($id, $data);
+                    $this->patch($id, $data);
+                    $return = $e->getResponse();
                     break;
                 }
 
@@ -415,7 +420,8 @@ abstract class AbstractRestfulController extends AbstractController
                 // instead of going to patchList
                 try {
                     $action = 'patchList';
-                    $return = $this->patchList($data);
+                    $this->patchList($data);
+                    $return = $e->getResponse();
                 } catch (Exception\RuntimeException $ex) {
                     $response = $e->getResponse();
                     $response->setStatusCode(405);
@@ -425,7 +431,8 @@ abstract class AbstractRestfulController extends AbstractController
             // POST
             case 'post':
                 $action = 'create';
-                $return = $this->processPostData($request);
+                $this->processPostData($request);
+                $return = $e->getResponse();
                 break;
             // PUT
             case 'put':
@@ -434,12 +441,14 @@ abstract class AbstractRestfulController extends AbstractController
 
                 if ($id !== false) {
                     $action = 'update';
-                    $return = $this->update($id, $data);
+                    $this->update($id, $data);
+                    $return = $e->getResponse();
                     break;
                 }
 
                 $action = 'replaceList';
-                $return = $this->replaceList($data);
+                $this->replaceList($data);
+                $return = $e->getResponse();
                 break;
             // All others...
             default:


### PR DESCRIPTION
Signed-off-by: Perses De Vilhena <persesvilhena@gmail.com>


|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

When any verb not implemented in the child class and a request is made on that method and there is no View for the method, an error is returned using "$ return = $ e-> getResponse ();" preventing the View class from being called, avoiding errors and slowness, there is no need to implement View, as it is a controller for restful APIs