### PR TITLE
Bugfix: Revert changing canonical name of `ControllerManager` service

### DIFF
--- a/src/Service/ServiceListenerFactory.php
+++ b/src/Service/ServiceListenerFactory.php
@@ -5,7 +5,6 @@ namespace Laminas\Mvc\Service;
 use Interop\Container\ContainerInterface;
 use Laminas\ModuleManager\Listener\ServiceListener;
 use Laminas\ModuleManager\Listener\ServiceListenerInterface;
-use Laminas\Mvc\Controller\ControllerManager;
 use Laminas\Mvc\View;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Factory\FactoryInterface;
@@ -53,13 +52,12 @@ class ServiceListenerFactory implements FactoryInterface
             'Laminas\View\Resolver\TemplatePathStack'      => 'ViewTemplatePathStack',
             'Laminas\View\Resolver\AggregateResolver'      => 'ViewResolver',
             'Laminas\View\Resolver\ResolverInterface'      => 'ViewResolver',
-            'ControllerManager'                            => ControllerManager::class,
         ],
         'invokables' => [],
         'factories'  => [
             'Application'                               => ApplicationFactory::class,
             'config'                                    => 'Laminas\Mvc\Service\ConfigFactory',
-            ControllerManager::class                    => 'Laminas\Mvc\Service\ControllerManagerFactory',
+            'ControllerManager'                         => 'Laminas\Mvc\Service\ControllerManagerFactory',
             'ControllerPluginManager'                   => 'Laminas\Mvc\Service\ControllerPluginManagerFactory',
             'DispatchListener'                          => 'Laminas\Mvc\Service\DispatchListenerFactory',
             'HttpExceptionStrategy'                     => HttpExceptionStrategyFactory::class,

--- a/src/Service/ServiceListenerFactory.php
+++ b/src/Service/ServiceListenerFactory.php
@@ -5,6 +5,7 @@ namespace Laminas\Mvc\Service;
 use Interop\Container\ContainerInterface;
 use Laminas\ModuleManager\Listener\ServiceListener;
 use Laminas\ModuleManager\Listener\ServiceListenerInterface;
+use Laminas\Mvc\Controller\ControllerManager;
 use Laminas\Mvc\View;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Factory\FactoryInterface;
@@ -52,6 +53,7 @@ class ServiceListenerFactory implements FactoryInterface
             'Laminas\View\Resolver\TemplatePathStack'      => 'ViewTemplatePathStack',
             'Laminas\View\Resolver\AggregateResolver'      => 'ViewResolver',
             'Laminas\View\Resolver\ResolverInterface'      => 'ViewResolver',
+            ControllerManager::class                       => 'ControllerManager',
         ],
         'invokables' => [],
         'factories'  => [

--- a/test/Application/BadControllerTrait.php
+++ b/test/Application/BadControllerTrait.php
@@ -50,10 +50,9 @@ trait BadControllerTrait
             [
                 'aliases' => [
                     'ControllerLoader'  => ControllerManager::class,
-                    'ControllerManager' => ControllerManager::class,
                 ],
                 'factories' => [
-                    ControllerManager::class => function ($services) {
+                    'ControllerManager' => function ($services) {
                         return new ControllerManager($services, ['factories' => [
                             'bad' => function () {
                                 return new BadController();

--- a/test/Application/InvalidControllerTypeTrait.php
+++ b/test/Application/InvalidControllerTypeTrait.php
@@ -49,10 +49,10 @@ trait InvalidControllerTypeTrait
             $serviceConfig,
             [
                 'aliases' => [
-                    'ControllerLoader' => ControllerManager::class,
+                    'ControllerLoader' => 'ControllerManager',
                 ],
                 'factories' => [
-                    ControllerManager::class => function ($services) {
+                    'ControllerManager' => function ($services) {
                         return new ControllerManager($services, ['factories' => [
                             'bad' => function () {
                                 return new stdClass();

--- a/test/Application/PathControllerTrait.php
+++ b/test/Application/PathControllerTrait.php
@@ -48,10 +48,9 @@ trait PathControllerTrait
             [
                 'aliases' => [
                     'ControllerLoader'  => ControllerManager::class,
-                    'ControllerManager' => ControllerManager::class,
                 ],
                 'factories' => [
-                    ControllerManager::class => function ($services) {
+                    'ControllerManager' => function ($services) {
                         return new ControllerManager($services, ['factories' => [
                             'path' => function () {
                                 return new TestAsset\PathController();

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -317,7 +317,7 @@ class ApplicationTest extends TestCase
         $router->addRoute('bad', $route);
 
         if ($addService) {
-            $this->serviceManager->setFactory(ControllerManager::class, function ($services) {
+            $this->serviceManager->setFactory('ControllerManager', function ($services) {
                 return new ControllerManager($services, ['factories' => [
                     'bad' => function () {
                         return new Controller\TestAsset\BadController();


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Pull Request #96 changed the canonical name of the `ControllerManager` service from the string `'ControllerManager'` to its FCQN `ControllerManager::class`. As this could be considered a BC break (and broke laminas/laminas-mvc-console because delegators don't work on aliases) this PR restores the previous configuration and adds `ControllerManager::class` as alias, instead.

fixes #99
