### PR TITLE
Update `quick-start.md` to fix typo in `composer create-project` command

### DIFF
--- a/docs/book/quick-start.md
+++ b/docs/book/quick-start.md
@@ -17,7 +17,7 @@ If you have not yet done so, [install Composer](https://getcomposer.org/doc/00-i
 Once you have, use the `create-project` command to create a new application:
 
 ```bash
-$ composer create-project -sdev laminas/laminas-mvc-skeleton my-application
+$ composer create-project -s dev laminas/laminas-mvc-skeleton my-application
 ```
 
 ## Create a Controller


### PR DESCRIPTION
Fix typo in suggested composer create-project command.

Fixes #106 

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default 3.3.x branch or the oldest support 3.x.x

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            ||no

### Description

The command as written creates a skeleton that generates errors.
