### PR TITLE
Remove Interop\Container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,11 +29,10 @@
     "require": {
         "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "ext-json": "*",
-        "container-interop/container-interop": "^1.2",
         "laminas/laminas-eventmanager": "^3.4",
         "laminas/laminas-http": "^2.15",
         "laminas/laminas-router": "^3.5",
-        "laminas/laminas-servicemanager": "^3.7",
+        "laminas/laminas-servicemanager": "^3.16.0",
         "laminas/laminas-stdlib": "^3.6",
         "laminas/laminas-view": "^2.14",
         "psr/container": "^1.1 || ^2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,44 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "56a36889ea3bd5f8d3882b68ce165263",
+    "content-hash": "67aac85e308353763bb1f8056101b8cc",
     "packages": [
-        {
-            "name": "container-interop/container-interop",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/container-interop/container-interop.git",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "shasum": ""
-            },
-            "require": {
-                "psr/container": "^1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Interop\\Container\\": "src/Interop/Container/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "homepage": "https://github.com/container-interop/container-interop",
-            "support": {
-                "issues": "https://github.com/container-interop/container-interop/issues",
-                "source": "https://github.com/container-interop/container-interop/tree/master"
-            },
-            "abandoned": "psr/container",
-            "time": "2017-02-14T19:40:03+00:00"
-        },
         {
             "name": "laminas/laminas-escaper",
             "version": "2.10.0",
@@ -355,37 +319,36 @@
         },
         {
             "name": "laminas/laminas-router",
-            "version": "3.5.0",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-router.git",
-                "reference": "44759e71620030c93d99e40b394fe9fff8f0beda"
+                "reference": "ebd084f7fda7520394b9ddc1e9ec2cbdf2094daa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-router/zipball/44759e71620030c93d99e40b394fe9fff8f0beda",
-                "reference": "44759e71620030c93d99e40b394fe9fff8f0beda",
+                "url": "https://api.github.com/repos/laminas/laminas-router/zipball/ebd084f7fda7520394b9ddc1e9ec2cbdf2094daa",
+                "reference": "ebd084f7fda7520394b9ddc1e9ec2cbdf2094daa",
                 "shasum": ""
             },
             "require": {
-                "container-interop/container-interop": "^1.2",
                 "laminas/laminas-http": "^2.15",
-                "laminas/laminas-servicemanager": "^3.7",
-                "laminas/laminas-stdlib": "^3.6",
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+                "laminas/laminas-servicemanager": "^3.14.0",
+                "laminas/laminas-stdlib": "^3.10.1",
+                "php": "^7.4 || ~8.0.0 || ~8.1.0"
             },
             "conflict": {
                 "zendframework/zend-router": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.2.1",
-                "laminas/laminas-i18n": "^2.7.4",
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "laminas/laminas-i18n": "^2.15.0",
                 "phpunit/phpunit": "^9.5.5",
-                "psalm/plugin-phpunit": "^0.15.1",
-                "vimeo/psalm": "^4.7"
+                "psalm/plugin-phpunit": "^0.17.0",
+                "vimeo/psalm": "^4.24.0"
             },
             "suggest": {
-                "laminas/laminas-i18n": "^2.7.4, if defining translatable HTTP path segments"
+                "laminas/laminas-i18n": "^2.15.0 if defining translatable HTTP path segments"
             },
             "type": "library",
             "extra": {
@@ -423,48 +386,50 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-10-13T16:02:43+00:00"
+            "time": "2022-08-30T22:41:24+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.10.0",
+            "version": "3.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "e52b985909e0940bf22d34f322eb3f48bbef6bd1"
+                "reference": "863c66733740cd36ebf5e700f4258ef2c68a2a24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/e52b985909e0940bf22d34f322eb3f48bbef6bd1",
-                "reference": "e52b985909e0940bf22d34f322eb3f48bbef6bd1",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/863c66733740cd36ebf5e700f4258ef2c68a2a24",
+                "reference": "863c66733740cd36ebf5e700f4258ef2c68a2a24",
                 "shasum": ""
             },
             "require": {
-                "container-interop/container-interop": "^1.2",
                 "laminas/laminas-stdlib": "^3.2.1",
                 "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
                 "psr/container": "^1.0"
             },
             "conflict": {
+                "ext-psr": "*",
                 "laminas/laminas-code": "<3.3.1",
                 "zendframework/zend-code": "<3.3.1",
                 "zendframework/zend-servicemanager": "*"
             },
             "provide": {
-                "container-interop/container-interop-implementation": "^1.2",
                 "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "container-interop/container-interop": "^1.2.0"
             },
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.0",
-                "laminas/laminas-coding-standard": "~2.2.1",
-                "laminas/laminas-container-config-test": "^0.3",
+                "laminas/laminas-coding-standard": "~2.3.0",
+                "laminas/laminas-container-config-test": "^0.7",
                 "laminas/laminas-dependency-plugin": "^2.1.2",
                 "mikey179/vfsstream": "^1.6.10@alpha",
                 "ocramius/proxy-manager": "^2.11",
                 "phpbench/phpbench": "^1.1",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5.5",
-                "psalm/plugin-phpunit": "^0.16.1",
+                "psalm/plugin-phpunit": "^0.17.0",
                 "vimeo/psalm": "^4.8"
             },
             "suggest": {
@@ -476,6 +441,9 @@
             ],
             "type": "library",
             "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
                 "psr-4": {
                     "Laminas\\ServiceManager\\": "src/"
                 }
@@ -509,7 +477,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-09-18T20:19:36+00:00"
+            "time": "2022-07-27T14:58:17+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
@@ -631,51 +599,47 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.19.0",
+            "version": "2.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "4875d4e58b6f728981bb767a60530540f82ee1df"
+                "reference": "f2ad7de3f92b443f31447a37e061116f701d150a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/4875d4e58b6f728981bb767a60530540f82ee1df",
-                "reference": "4875d4e58b6f728981bb767a60530540f82ee1df",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/f2ad7de3f92b443f31447a37e061116f701d150a",
+                "reference": "f2ad7de3f92b443f31447a37e061116f701d150a",
                 "shasum": ""
             },
             "require": {
-                "container-interop/container-interop": "^1.1",
+                "laminas/laminas-servicemanager": "^3.12.0",
                 "laminas/laminas-stdlib": "^3.10",
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+                "php": "^7.4 || ~8.0.0 || ~8.1.0"
             },
             "conflict": {
                 "zendframework/zend-validator": "*"
             },
             "require-dev": {
-                "laminas/laminas-cache": "^2.6.1",
-                "laminas/laminas-coding-standard": "~2.2.1",
-                "laminas/laminas-db": "^2.7",
-                "laminas/laminas-filter": "^2.6",
-                "laminas/laminas-http": "^2.14.2",
-                "laminas/laminas-i18n": "^2.6",
-                "laminas/laminas-math": "^2.6",
-                "laminas/laminas-servicemanager": "^2.7.11 || ^3.0.3",
-                "laminas/laminas-session": "^2.8",
-                "laminas/laminas-uri": "^2.7",
+                "laminas/laminas-coding-standard": "^2.4.0",
+                "laminas/laminas-db": "^2.15.0",
+                "laminas/laminas-filter": "^2.18.0",
+                "laminas/laminas-http": "^2.16.0",
+                "laminas/laminas-i18n": "^2.17.0",
+                "laminas/laminas-session": "^2.13.0",
+                "laminas/laminas-uri": "^2.9.1",
                 "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5.5",
-                "psalm/plugin-phpunit": "^0.15.0",
+                "phpunit/phpunit": "^9.5.24",
+                "psalm/plugin-phpunit": "^0.17.0",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0",
-                "vimeo/psalm": "^4.3"
+                "vimeo/psalm": "^4.27.0"
             },
             "suggest": {
                 "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
                 "laminas/laminas-filter": "Laminas\\Filter component, required by the Digits validator",
                 "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
                 "laminas/laminas-i18n-resources": "Translations of validator messages",
-                "laminas/laminas-math": "Laminas\\Math component, required by the Csrf validator",
                 "laminas/laminas-servicemanager": "Laminas\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
                 "laminas/laminas-session": "Laminas\\Session component, ^2.8; required by the Csrf validator",
                 "laminas/laminas-uri": "Laminas\\Uri component, required by the Uri and Sitemap\\Loc validators",
@@ -717,20 +681,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-06-09T21:49:40+00:00"
+            "time": "2022-09-13T07:40:10+00:00"
         },
         {
             "name": "laminas/laminas-view",
-            "version": "2.20.0",
+            "version": "2.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-view.git",
-                "reference": "2cd6973a3e042be3d244260fe93f435668f5c2b4"
+                "reference": "69ea122cd53f7839e58cb250975932332e542524"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-view/zipball/2cd6973a3e042be3d244260fe93f435668f5c2b4",
-                "reference": "2cd6973a3e042be3d244260fe93f435668f5c2b4",
+                "url": "https://api.github.com/repos/laminas/laminas-view/zipball/69ea122cd53f7839e58cb250975932332e542524",
+                "reference": "69ea122cd53f7839e58cb250975932332e542524",
                 "shasum": ""
             },
             "require": {
@@ -741,8 +705,8 @@
                 "laminas/laminas-escaper": "^2.5",
                 "laminas/laminas-eventmanager": "^3.4",
                 "laminas/laminas-json": "^3.3",
-                "laminas/laminas-servicemanager": "^3.10",
-                "laminas/laminas-stdlib": "^3.6",
+                "laminas/laminas-servicemanager": "^3.14.0",
+                "laminas/laminas-stdlib": "^3.10.1",
                 "php": "^7.4 || ~8.0.0 || ~8.1.0",
                 "psr/container": "^1 || ^2"
             },
@@ -773,7 +737,7 @@
                 "phpspec/prophecy": "^1.12",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5.5",
-                "psalm/plugin-phpunit": "^0.16.1",
+                "psalm/plugin-phpunit": "^0.17.0",
                 "vimeo/psalm": "^4.10"
             },
             "suggest": {
@@ -824,7 +788,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-02-22T13:52:44+00:00"
+            "time": "2022-09-19T15:43:14+00:00"
         },
         {
             "name": "psr/container",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,7 +9,7 @@
     <arg name="parallel" value="80"/>
 
     <!-- Show progress -->
-    <arg value="p"/>
+    <arg value="ps"/>
 
     <!-- Paths to check -->
     <file>src</file>

--- a/src/Controller/ControllerManager.php
+++ b/src/Controller/ControllerManager.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Controller;
 
-use Interop\Container\ContainerInterface;
 use Laminas\EventManager\EventManagerAwareInterface;
 use Laminas\EventManager\SharedEventManagerInterface;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\ConfigInterface;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\Stdlib\DispatchableInterface;
+use Psr\Container\ContainerInterface;
 
 use function get_class;
 use function gettype;

--- a/src/Controller/LazyControllerAbstractFactory.php
+++ b/src/Controller/LazyControllerAbstractFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Controller;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Console\Adapter\AdapterInterface as ConsoleAdapterInterface;
 use Laminas\Filter\FilterPluginManager;
 use Laminas\Hydrator\HydratorPluginManager;
@@ -18,6 +17,7 @@ use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 use Laminas\Stdlib\DispatchableInterface;
 use Laminas\Validator\ValidatorPluginManager;
+use Psr\Container\ContainerInterface;
 use ReflectionClass;
 use ReflectionParameter;
 

--- a/src/Controller/Plugin/Service/ForwardFactory.php
+++ b/src/Controller/Plugin/Service/ForwardFactory.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Controller\Plugin\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Mvc\Controller\Plugin\Forward;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 use function sprintf;
 

--- a/src/Service/AbstractPluginManagerFactory.php
+++ b/src/Service/AbstractPluginManagerFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 abstract class AbstractPluginManagerFactory implements FactoryInterface
 {

--- a/src/Service/ApplicationFactory.php
+++ b/src/Service/ApplicationFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Mvc\Application;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 class ApplicationFactory implements FactoryInterface
 {

--- a/src/Service/ControllerManagerFactory.php
+++ b/src/Service/ControllerManagerFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Mvc\Controller\ControllerManager;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 class ControllerManagerFactory implements FactoryInterface
 {

--- a/src/Service/ControllerPluginManagerFactory.php
+++ b/src/Service/ControllerPluginManagerFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Mvc\Controller\PluginManager as ControllerPluginManager;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 class ControllerPluginManagerFactory implements FactoryInterface
 {

--- a/src/Service/DispatchListenerFactory.php
+++ b/src/Service/DispatchListenerFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Mvc\DispatchListener;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 class DispatchListenerFactory implements FactoryInterface
 {

--- a/src/Service/EventManagerFactory.php
+++ b/src/Service/EventManagerFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\EventManager\EventManager;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 class EventManagerFactory implements FactoryInterface
 {

--- a/src/Service/HttpDefaultRenderingStrategyFactory.php
+++ b/src/Service/HttpDefaultRenderingStrategyFactory.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Mvc\View\Http\DefaultRenderingStrategy;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\View\View;
+use Psr\Container\ContainerInterface;
 
 class HttpDefaultRenderingStrategyFactory implements FactoryInterface
 {

--- a/src/Service/HttpExceptionStrategyFactory.php
+++ b/src/Service/HttpExceptionStrategyFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Mvc\View\Http\ExceptionStrategy;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 class HttpExceptionStrategyFactory implements FactoryInterface
 {

--- a/src/Service/HttpMethodListenerFactory.php
+++ b/src/Service/HttpMethodListenerFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Mvc\HttpMethodListener;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 use function array_key_exists;
 use function is_array;

--- a/src/Service/HttpRouteNotFoundStrategyFactory.php
+++ b/src/Service/HttpRouteNotFoundStrategyFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Mvc\View\Http\RouteNotFoundStrategy;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 class HttpRouteNotFoundStrategyFactory implements FactoryInterface
 {

--- a/src/Service/HttpViewManagerConfigTrait.php
+++ b/src/Service/HttpViewManagerConfigTrait.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Mvc\Service;
 
 use ArrayAccess;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 use function is_array;
 

--- a/src/Service/HttpViewManagerFactory.php
+++ b/src/Service/HttpViewManagerFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Mvc\View\Http\ViewManager as HttpViewManager;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 class HttpViewManagerFactory implements FactoryInterface
 {

--- a/src/Service/InjectTemplateListenerFactory.php
+++ b/src/Service/InjectTemplateListenerFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Mvc\View\Http\InjectTemplateListener;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 use function is_array;
 

--- a/src/Service/RequestFactory.php
+++ b/src/Service/RequestFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Http\PhpEnvironment\Request as HttpRequest;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 class RequestFactory implements FactoryInterface
 {

--- a/src/Service/ResponseFactory.php
+++ b/src/Service/ResponseFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Http\PhpEnvironment\Response as HttpResponse;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 class ResponseFactory implements FactoryInterface
 {

--- a/src/Service/SendResponseListenerFactory.php
+++ b/src/Service/SendResponseListenerFactory.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Mvc\SendResponseListener;
+use Psr\Container\ContainerInterface;
 
 class SendResponseListenerFactory
 {

--- a/src/Service/ViewFactory.php
+++ b/src/Service/ViewFactory.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\View\Strategy\PhpRendererStrategy;
 use Laminas\View\View;
+use Psr\Container\ContainerInterface;
 
 class ViewFactory implements FactoryInterface
 {

--- a/src/Service/ViewFeedStrategyFactory.php
+++ b/src/Service/ViewFeedStrategyFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\View\Strategy\FeedStrategy;
+use Psr\Container\ContainerInterface;
 
 class ViewFeedStrategyFactory implements FactoryInterface
 {

--- a/src/Service/ViewHelperManagerFactory.php
+++ b/src/Service/ViewHelperManagerFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Router\RouteMatch;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Factory\FactoryInterface;
@@ -13,6 +12,7 @@ use Laminas\View\Helper\BasePath;
 use Laminas\View\Helper\Doctype;
 use Laminas\View\Helper\Url;
 use Laminas\View\HelperPluginManager;
+use Psr\Container\ContainerInterface;
 
 use function is_callable;
 

--- a/src/Service/ViewJsonStrategyFactory.php
+++ b/src/Service/ViewJsonStrategyFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\View\Strategy\JsonStrategy;
+use Psr\Container\ContainerInterface;
 
 class ViewJsonStrategyFactory implements FactoryInterface
 {

--- a/src/Service/ViewManagerFactory.php
+++ b/src/Service/ViewManagerFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Mvc\View\Http\ViewManager as HttpViewManager;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 class ViewManagerFactory implements FactoryInterface
 {

--- a/src/Service/ViewPhpRendererFactory.php
+++ b/src/Service/ViewPhpRendererFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\View\Renderer\PhpRenderer;
+use Psr\Container\ContainerInterface;
 
 class ViewPhpRendererFactory implements FactoryInterface
 {

--- a/src/Service/ViewPhpRendererStrategyFactory.php
+++ b/src/Service/ViewPhpRendererStrategyFactory.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\View\Renderer\PhpRenderer;
 use Laminas\View\Strategy\PhpRendererStrategy;
+use Psr\Container\ContainerInterface;
 
 class ViewPhpRendererStrategyFactory implements FactoryInterface
 {

--- a/src/Service/ViewPrefixPathStackResolverFactory.php
+++ b/src/Service/ViewPrefixPathStackResolverFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\View\Resolver\PrefixPathStackResolver;
+use Psr\Container\ContainerInterface;
 
 class ViewPrefixPathStackResolverFactory implements FactoryInterface
 {

--- a/src/Service/ViewResolverFactory.php
+++ b/src/Service/ViewResolverFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\View\Resolver as ViewResolver;
+use Psr\Container\ContainerInterface;
 
 class ViewResolverFactory implements FactoryInterface
 {

--- a/src/Service/ViewTemplateMapResolverFactory.php
+++ b/src/Service/ViewTemplateMapResolverFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\View\Resolver as ViewResolver;
+use Psr\Container\ContainerInterface;
 
 use function is_array;
 

--- a/src/Service/ViewTemplatePathStackFactory.php
+++ b/src/Service/ViewTemplatePathStackFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\View\Resolver as ViewResolver;
+use Psr\Container\ContainerInterface;
 
 use function is_array;
 

--- a/test/Controller/LazyControllerAbstractFactoryTest.php
+++ b/test/Controller/LazyControllerAbstractFactoryTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace LaminasTest\Mvc\Controller;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Mvc\Controller\LazyControllerAbstractFactory;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\Validator\ValidatorPluginManager;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Container\ContainerInterface;
 use ZendTest\Mvc\Controller\TestAsset\SampleInterface;
 
 use function sprintf;

--- a/test/Controller/Plugin/TestAsset/SamplePluginFactory.php
+++ b/test/Controller/Plugin/TestAsset/SamplePluginFactory.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace LaminasTest\Mvc\Controller\Plugin\TestAsset;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 class SamplePluginFactory implements FactoryInterface
 {

--- a/test/Controller/Plugin/TestAsset/SamplePluginWithConstructorFactory.php
+++ b/test/Controller/Plugin/TestAsset/SamplePluginWithConstructorFactory.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace LaminasTest\Mvc\Controller\Plugin\TestAsset;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 class SamplePluginWithConstructorFactory implements FactoryInterface
 {

--- a/test/Controller/TestAsset/ControllerLoaderAbstractFactory.php
+++ b/test/Controller/TestAsset/ControllerLoaderAbstractFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace LaminasTest\Mvc\Controller\TestAsset;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 use LaminasTest\Mvc\TestAsset\PathController;
+use Psr\Container\ContainerInterface;
 
 use function class_exists;
 

--- a/test/Controller/TestAsset/UnlocatableControllerLoaderAbstractFactory.php
+++ b/test/Controller/TestAsset/UnlocatableControllerLoaderAbstractFactory.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace LaminasTest\Mvc\Controller\TestAsset;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
+use Psr\Container\ContainerInterface;
 
 class UnlocatableControllerLoaderAbstractFactory implements AbstractFactoryInterface
 {

--- a/test/Service/HttpMethodListenerFactoryTest.php
+++ b/test/Service/HttpMethodListenerFactoryTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace LaminasTest\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Mvc\Service\HttpMethodListenerFactory;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Container\ContainerInterface;
 
 /**
  * @covers Laminas\Mvc\Service\HttpMethodListenerFactory

--- a/test/Service/InjectTemplateListenerFactoryTest.php
+++ b/test/Service/InjectTemplateListenerFactoryTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace LaminasTest\Mvc\Service;
 
 use ArrayObject;
-use Interop\Container\ContainerInterface;
 use Laminas\Mvc\Service\InjectTemplateListenerFactory;
 use Laminas\Mvc\View\Http\InjectTemplateListener;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Container\ContainerInterface;
 
 /**
  * Tests for {@see \Laminas\Mvc\Service\InjectTemplateListenerFactory}

--- a/test/Service/RequestFactoryTest.php
+++ b/test/Service/RequestFactoryTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace LaminasTest\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Http\Request as HttpRequest;
 use Laminas\Mvc\Service\RequestFactory;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Container\ContainerInterface;
 
 class RequestFactoryTest extends TestCase
 {

--- a/test/Service/ResponseFactoryTest.php
+++ b/test/Service/ResponseFactoryTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace LaminasTest\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Http\Response as HttpResponse;
 use Laminas\Mvc\Service\ResponseFactory;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Container\ContainerInterface;
 
 class ResponseFactoryTest extends TestCase
 {

--- a/test/Service/SendResponseListenerFactoryTest.php
+++ b/test/Service/SendResponseListenerFactoryTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace LaminasTest\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\EventManager\SharedEventManagerInterface;
 use Laminas\Mvc\ResponseSender\HttpResponseSender;
@@ -16,6 +15,7 @@ use Laminas\Mvc\Service\SendResponseListenerFactory;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Container\ContainerInterface;
 
 class SendResponseListenerFactoryTest extends TestCase
 {

--- a/test/Service/ViewFeedStrategyFactoryTest.php
+++ b/test/Service/ViewFeedStrategyFactoryTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace LaminasTest\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Mvc\Service\ViewFeedStrategyFactory;
 use Laminas\View\Renderer\FeedRenderer;
 use Laminas\View\Strategy\FeedStrategy;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Container\ContainerInterface;
 
 class ViewFeedStrategyFactoryTest extends TestCase
 {

--- a/test/Service/ViewJsonStrategyFactoryTest.php
+++ b/test/Service/ViewJsonStrategyFactoryTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace LaminasTest\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Mvc\Service\ViewJsonStrategyFactory;
 use Laminas\View\Renderer\JsonRenderer;
 use Laminas\View\Strategy\JsonStrategy;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Container\ContainerInterface;
 
 class ViewJsonStrategyFactoryTest extends TestCase
 {

--- a/test/Service/ViewManagerFactoryTest.php
+++ b/test/Service/ViewManagerFactoryTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace LaminasTest\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Mvc\Service\ViewManagerFactory;
 use Laminas\Mvc\View\Http\ViewManager as HttpViewManager;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Container\ContainerInterface;
 
 class ViewManagerFactoryTest extends TestCase
 {

--- a/test/Service/ViewPrefixPathStackResolverFactoryTest.php
+++ b/test/Service/ViewPrefixPathStackResolverFactoryTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace LaminasTest\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Mvc\Service\ViewPrefixPathStackResolverFactory;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\View\Resolver\PrefixPathStackResolver;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Container\ContainerInterface;
 
 class ViewPrefixPathStackResolverFactoryTest extends TestCase
 {


### PR DESCRIPTION
Bumps ServiceManager to 3.16 removing `interop/container` in favour of `psr/container`

Closes #113 