### PR TITLE
Drop irrelevant and obsolete composer suggests.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,24 +39,19 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "2.4.0",
-        "laminas/laminas-json": "^3.3",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5.24",
         "psalm/plugin-phpunit": "^0.17.0",
         "vimeo/psalm": "^4.27.0"
     },
     "suggest": {
-        "laminas/laminas-json": "(^2.6.1 || ^3.0) To auto-deserialize JSON body content in AbstractRestfulController extensions, when json_decode is unavailable",
-        "laminas/laminas-log": "^2.9.1  To provide log functionality via LogFilterManager, LogFormatterManager, and LogProcessorManager",
-        "laminas/laminas-mvc-console": "laminas-mvc-console provides the ability to expose laminas-mvc as a console application",
         "laminas/laminas-mvc-i18n": "laminas-mvc-i18n provides integration with laminas-i18n, including a translation bridge and translatable route segments",
         "laminas/laminas-mvc-middleware": "To dispatch middleware in your laminas-mvc application",
         "laminas/laminas-mvc-plugin-fileprg": "To provide Post/Redirect/Get functionality around forms that container file uploads",
         "laminas/laminas-mvc-plugin-flashmessenger": "To provide flash messaging capabilities between requests",
         "laminas/laminas-mvc-plugin-identity": "To access the authenticated identity (per laminas-authentication) in controllers",
         "laminas/laminas-mvc-plugin-prg": "To provide Post/Redirect/Get functionality within controllers",
-        "laminas/laminas-paginator": "^2.7 To provide pagination functionality via PaginatorPluginManager",
-        "laminas/laminas-servicemanager-di": "laminas-servicemanager-di provides utilities for integrating laminas-di and laminas-servicemanager in your laminas-mvc application"
+        "laminas/laminas-paginator": "^2.7 To provide pagination functionality via PaginatorPluginManager"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d4156ce8463382061047ab3a1d3512be",
+    "content-hash": "e4d43e607f5a264560c49b8d205ee973",
     "packages": [
         {
             "name": "laminas/laminas-escaper",

--- a/src/Controller/AbstractRestfulController.php
+++ b/src/Controller/AbstractRestfulController.php
@@ -61,13 +61,7 @@ abstract class AbstractRestfulController extends AbstractController
     protected $identifierName = 'id';
 
     /**
-     * Flag to pass to json_decode and/or Laminas\Json\Json::decode.
-     *
-     * The flags in Laminas\Json\Json::decode are integers, but when evaluated
-     * in a boolean context map to the flag passed as the second parameter
-     * to json_decode(). As such, you can specify either the Laminas\Json\Json
-     * constant or the boolean value. By default, starting in v3, we use
-     * the boolean value, and cast to integer if using Laminas\Json\Json::decode.
+     * Flag to pass to json_decode.
      *
      * Default value is boolean true, meaning JSON should be cast to
      * associative arrays (vs objects).
@@ -75,7 +69,7 @@ abstract class AbstractRestfulController extends AbstractController
      * Override the value in an extending class to set the default behavior
      * for your class.
      *
-     * @var int|bool
+     * @var bool
      */
     protected $jsonDecodeType = true;
 
@@ -615,9 +609,6 @@ abstract class AbstractRestfulController extends AbstractController
 
     /**
      * Decode a JSON string.
-     *
-     * Uses json_decode by default. If that is not available, checks for
-     * availability of Laminas\Json\Json, and uses that if present.
      *
      * Otherwise, raises an exception.
      *


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Composer suggest refers to console package that was deprecated and abandoned as well as some other packages that are not directly related to this package.

Also removing lingering references to Laminas\Json in phpdoc comments.

Suggestion for laminas-paginator is ought to be removed too but there is paginator plugin factory so technically it is relevant as of now. 