### PR TITLE
Lazy controller factory incompatibility with PHP 8

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d1d8e7f5c6c58431100bf2ff5d7a2d2b",
+    "content-hash": "84d1d16b003b89e011e8416202062d15",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -1646,9 +1646,6 @@
             "require": {
                 "php": "^7.1 || ^8.0"
             },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
-            },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
@@ -1656,12 +1653,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2456,11 +2453,11 @@
                 }
             },
             "autoload": {
-                "classmap": [
-                    "src/"
-                ],
                 "files": [
                     "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -3683,12 +3680,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3894,5 +3891,8 @@
         "php": "^7.3 || ~8.0.0 || ~8.1.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "platform-overrides": {
+        "php": "7.3.99"
+    },
+    "plugin-api-version": "2.3.0"
 }

--- a/test/Controller/LazyControllerAbstractFactoryTest.php
+++ b/test/Controller/LazyControllerAbstractFactoryTest.php
@@ -4,10 +4,12 @@ namespace LaminasTest\Mvc\Controller;
 
 use Interop\Container\ContainerInterface;
 use Laminas\Mvc\Controller\LazyControllerAbstractFactory;
+use Laminas\Mvc\Exception\DomainException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\Validator\ValidatorPluginManager;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use TypeError;
 
 class LazyControllerAbstractFactoryTest extends TestCase
 {
@@ -73,6 +75,23 @@ class LazyControllerAbstractFactoryTest extends TestCase
             )
         );
         $factory($this->container->reveal(), TestAsset\ControllerWithTypeHintedConstructorParameter::class);
+    }
+
+    /**
+     * @requires PHP >= 8.0
+     */
+    public function testFactoryRaisesExceptionWhenResolvingUnionTypeHintedService(): void
+    {
+        $this->container->has(TestAsset\SampleInterface::class)->willReturn(false);
+        $factory = new LazyControllerAbstractFactory();
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage(
+            sprintf(
+                'Unable to create controller "%s"; unable to resolve parameter "sample" with union type hint',
+                TestAsset\ControllerWithUnionTypeHintedConstructorParameter::class
+            )
+        );
+        $factory($this->container->reveal(), TestAsset\ControllerWithUnionTypeHintedConstructorParameter::class);
     }
 
     public function testFactoryPassesNullForScalarParameters()

--- a/test/Controller/LazyControllerAbstractFactoryTest.php
+++ b/test/Controller/LazyControllerAbstractFactoryTest.php
@@ -9,7 +9,6 @@ use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\Validator\ValidatorPluginManager;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
-use TypeError;
 
 class LazyControllerAbstractFactoryTest extends TestCase
 {

--- a/test/Controller/TestAsset/ControllerWithUnionTypeHintedConstructorParameter.php
+++ b/test/Controller/TestAsset/ControllerWithUnionTypeHintedConstructorParameter.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace LaminasTest\Mvc\Controller\TestAsset;
+
+use Laminas\Mvc\Controller\AbstractActionController;
+
+class ControllerWithUnionTypeHintedConstructorParameter extends AbstractActionController
+{
+    public $sample;
+
+    public function __construct(SampleInterface|AnotherSampleInterface $sample)
+    {
+        $this->sample = $sample;
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Lazy controller factory is trying to get typehint type names for controller constructor parameters using reflection but method is not always available under PHP >=8.0. Specifically it is not available for union or intersection typehints.

Lazy controller factory can not resolve union or intersection factory. This fix does not bring that as a new feature and addresses undefined method call instead