### PR TITLE
Removed abandoned laminas-json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,12 +40,10 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "^3.0.1",
-        "laminas/laminas-json": "^3.7",
         "phpunit/phpunit": "^10.5.38",
         "webmozart/assert": "^1.11"
     },
     "suggest": {
-        "laminas/laminas-json": "(^2.6.1 || ^3.0) To auto-deserialize JSON body content in AbstractRestfulController extensions, when json_decode is unavailable",
         "laminas/laminas-log": "^2.9.1  To provide log functionality via LogFilterManager, LogFormatterManager, and LogProcessorManager",
         "laminas/laminas-mvc-console": "laminas-mvc-console provides the ability to expose laminas-mvc as a console application",
         "laminas/laminas-mvc-i18n": "laminas-mvc-i18n provides integration with laminas-i18n, including a translation bridge and translatable route segments",

--- a/src/Controller/AbstractRestfulController.php
+++ b/src/Controller/AbstractRestfulController.php
@@ -16,7 +16,6 @@ use Laminas\Stdlib\ResponseInterface as Response;
 use function array_key_exists;
 use function array_shift;
 use function call_user_func;
-use function class_exists;
 use function count;
 use function explode;
 use function function_exists;

--- a/src/Controller/AbstractRestfulController.php
+++ b/src/Controller/AbstractRestfulController.php
@@ -4,7 +4,6 @@ namespace Laminas\Mvc\Controller;
 
 use Laminas\Http\Header\ContentType;
 use Laminas\Http\Request as HttpRequest;
-use Laminas\Json\Json;
 use Laminas\Mvc\Exception;
 use Laminas\Mvc\Exception\DomainException;
 use Laminas\Mvc\Exception\InvalidArgumentException;
@@ -62,13 +61,7 @@ abstract class AbstractRestfulController extends AbstractController
     protected $identifierName = 'id';
 
     /**
-     * Flag to pass to json_decode and/or Laminas\Json\Json::decode.
-     *
-     * The flags in Laminas\Json\Json::decode are integers, but when evaluated
-     * in a boolean context map to the flag passed as the second parameter
-     * to json_decode(). As such, you can specify either the Laminas\Json\Json
-     * constant or the boolean value. By default, starting in v3, we use
-     * the boolean value, and cast to integer if using Laminas\Json\Json::decode.
+     * Flag to pass to json_decode.
      *
      * Default value is boolean true, meaning JSON should be cast to
      * associative arrays (vs objects).
@@ -76,7 +69,7 @@ abstract class AbstractRestfulController extends AbstractController
      * Override the value in an extending class to set the default behavior
      * for your class.
      *
-     * @var int|bool
+     * @var bool
      */
     protected $jsonDecodeType = true;
 
@@ -609,10 +602,7 @@ abstract class AbstractRestfulController extends AbstractController
     /**
      * Decode a JSON string.
      *
-     * Uses json_decode by default. If that is not available, checks for
-     * availability of Laminas\Json\Json, and uses that if present.
-     *
-     * Otherwise, raises an exception.
+     * Uses json_decode by default. If that is not available, raises an exception.
      *
      * Marked protected to allow usage from extending classes.
      *
@@ -626,13 +616,8 @@ abstract class AbstractRestfulController extends AbstractController
             return json_decode($string, (bool) $this->jsonDecodeType);
         }
 
-        if (class_exists(Json::class)) {
-            return Json::decode($string, (int) $this->jsonDecodeType);
-        }
-
-        throw new DomainException(sprintf(
-            'Unable to parse JSON request, due to missing ext/json and/or %s',
-            Json::class
-        ));
+        throw new DomainException(
+            'Unable to parse JSON request, due to missing ext/json'
+        );
     }
 }

--- a/src/Controller/AbstractRestfulController.php
+++ b/src/Controller/AbstractRestfulController.php
@@ -18,7 +18,6 @@ use function array_shift;
 use function call_user_func;
 use function count;
 use function explode;
-use function function_exists;
 use function get_debug_type;
 use function is_array;
 use function is_callable;
@@ -601,22 +600,15 @@ abstract class AbstractRestfulController extends AbstractController
     /**
      * Decode a JSON string.
      *
-     * Uses json_decode by default. If that is not available, raises an exception.
+     * Uses json_decode by default.
      *
      * Marked protected to allow usage from extending classes.
      *
      * @param string $string
      * @return mixed
-     * @throws Exception\DomainException If no JSON decoding functionality is available.
      */
     protected function jsonDecode($string)
     {
-        if (function_exists('json_decode')) {
-            return json_decode($string, (bool) $this->jsonDecodeType);
-        }
-
-        throw new DomainException(
-            'Unable to parse JSON request, due to missing ext/json'
-        );
+        return json_decode($string, (bool) $this->jsonDecodeType);
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description
Per PHP documentation, json_decode is always available starting with PHP 8.0 "As of PHP 8.0.0, the JSON extension is a core PHP extension, so it is always enabled." Reference: https://www.php.net/manual/en/json.installation.php
This PR removes the fallback to laminas-json which is abandoned and completes issue https://github.com/laminas/laminas-mvc/issues/177

Signed-off-by: Mathias Berchtold <mberchtold@gmail.com>