### PR TITLE
Upgrade to laminas/laminas-servicemanager to v4.1.0 in branch 3.9.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "laminas/laminas-http": "^2.15",
         "laminas/laminas-modulemanager": "^2.16",
         "laminas/laminas-router": "^3.11.1",
-        "laminas/laminas-servicemanager": "^3.20.0",
+        "laminas/laminas-servicemanager": "^4.1.0",
         "laminas/laminas-stdlib": "^3.19",
         "laminas/laminas-view": "^2.18.0"
     },

--- a/src/Controller/ControllerManager.php
+++ b/src/Controller/ControllerManager.php
@@ -42,13 +42,13 @@ class ControllerManager extends AbstractPluginManager
      * Injects an initializer for injecting controllers with an
      * event manager and plugin manager.
      *
-     * @param  ConfigInterface|ContainerInterface $configOrContainerInstance
+     * @param  ConfigInterface|ContainerInterface $configInstanceOrParentLocator
      */
-    public function __construct($configOrContainerInstance, array $config = [])
+    public function __construct($configInstanceOrParentLocator = null, array $config = [])
     {
         $this->addInitializer([$this, 'injectEventManager']);
         $this->addInitializer([$this, 'injectPluginManager']);
-        parent::__construct($configOrContainerInstance, $config);
+        parent::__construct($configInstanceOrParentLocator, $config);
     }
 
     /**
@@ -56,7 +56,7 @@ class ControllerManager extends AbstractPluginManager
      *
      * {@inheritDoc}
      */
-    public function validate($plugin)
+    public function validate(mixed $plugin)
     {
         if (! $plugin instanceof $this->instanceOf) {
             throw new InvalidServiceException(sprintf(

--- a/src/Controller/PluginManager.php
+++ b/src/Controller/PluginManager.php
@@ -169,7 +169,7 @@ class PluginManager extends AbstractPluginManager
      *
      * {@inheritDoc}
      */
-    public function validate($plugin)
+    public function validate(mixed $plugin)
     {
         if (! $plugin instanceof $this->instanceOf) {
             throw new InvalidServiceException(sprintf(

--- a/test/Application/AllowsReturningEarlyFromRoutingTest.php
+++ b/test/Application/AllowsReturningEarlyFromRoutingTest.php
@@ -21,7 +21,7 @@ class AllowsReturningEarlyFromRoutingTest extends TestCase
         $application->getEventManager()->attach(MvcEvent::EVENT_ROUTE, static fn($e): Response => $response);
 
         $result = $application->run();
-        $this->assertSame($application, $result);
-        $this->assertSame($response, $result->getResponse());
+        self::assertSame($application, $result);
+        self::assertSame($response, $result->getResponse());
     }
 }

--- a/test/Application/ControllerIsDispatchedTest.php
+++ b/test/Application/ControllerIsDispatchedTest.php
@@ -16,7 +16,7 @@ class ControllerIsDispatchedTest extends TestCase
         $application = $this->prepareApplication();
 
         $response = $application->run()->getResponse();
-        $this->assertStringContainsString('PathController', $response->getContent());
-        $this->assertStringContainsString(MvcEvent::EVENT_DISPATCH, $response->toString());
+        self::assertStringContainsString('PathController', $response->getContent());
+        self::assertStringContainsString(MvcEvent::EVENT_DISPATCH, $response->toString());
     }
 }

--- a/test/Application/ExceptionsRaisedInDispatchableShouldRaiseDispatchErrorEventTest.php
+++ b/test/Application/ExceptionsRaisedInDispatchableShouldRaiseDispatchErrorEventTest.php
@@ -22,12 +22,12 @@ class ExceptionsRaisedInDispatchableShouldRaiseDispatchErrorEventTest extends Te
         $events   = $application->getEventManager();
         $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, function ($e) use ($response) {
             $exception = $e->getParam('exception');
-            $this->assertInstanceOf('Exception', $exception);
+            self::assertInstanceOf('Exception', $exception);
             $response->setContent($exception->getMessage());
             return $response;
         });
 
         $application->run();
-        $this->assertStringContainsString('Raised an exception', $response->getContent());
+        self::assertStringContainsString('Raised an exception', $response->getContent());
     }
 }

--- a/test/Application/InabilityToRetrieveControllerShouldTriggerDispatchErrorTest.php
+++ b/test/Application/InabilityToRetrieveControllerShouldTriggerDispatchErrorTest.php
@@ -29,7 +29,7 @@ class InabilityToRetrieveControllerShouldTriggerDispatchErrorTest extends TestCa
         });
 
         $application->run();
-        $this->assertStringContainsString(Application::ERROR_CONTROLLER_NOT_FOUND, $response->getContent());
-        $this->assertStringContainsString('bad', $response->getContent());
+        self::assertStringContainsString(Application::ERROR_CONTROLLER_NOT_FOUND, $response->getContent());
+        self::assertStringContainsString('bad', $response->getContent());
     }
 }

--- a/test/Application/InabilityToRetrieveControllerShouldTriggerExceptionTest.php
+++ b/test/Application/InabilityToRetrieveControllerShouldTriggerExceptionTest.php
@@ -29,7 +29,7 @@ class InabilityToRetrieveControllerShouldTriggerExceptionTest extends TestCase
         });
 
         $application->run();
-        $this->assertStringContainsString(Application::ERROR_CONTROLLER_NOT_FOUND, $response->getContent());
-        $this->assertStringContainsString('bad', $response->getContent());
+        self::assertStringContainsString(Application::ERROR_CONTROLLER_NOT_FOUND, $response->getContent());
+        self::assertStringContainsString('bad', $response->getContent());
     }
 }

--- a/test/Application/InitializationIntegrationTest.php
+++ b/test/Application/InitializationIntegrationTest.php
@@ -39,8 +39,8 @@ class InitializationIntegrationTest extends TestCase
         $content = ob_get_clean();
 
         $response = $application->getResponse();
-        $this->assertStringContainsString(PathController::class, $response->getContent());
-        $this->assertStringContainsString(PathController::class, $content);
-        $this->assertStringContainsString(MvcEvent::EVENT_DISPATCH, $response->toString());
+        self::assertStringContainsString(PathController::class, $response->getContent());
+        self::assertStringContainsString(PathController::class, $content);
+        self::assertStringContainsString(MvcEvent::EVENT_DISPATCH, $response->toString());
     }
 }

--- a/test/Application/InvalidControllerTypeShouldTriggerDispatchErrorTest.php
+++ b/test/Application/InvalidControllerTypeShouldTriggerDispatchErrorTest.php
@@ -30,7 +30,7 @@ class InvalidControllerTypeShouldTriggerDispatchErrorTest extends TestCase
         });
 
         $application->run();
-        $this->assertStringContainsString(Application::ERROR_CONTROLLER_INVALID, $response->getContent());
-        $this->assertStringContainsString('bad', $response->getContent());
+        self::assertStringContainsString(Application::ERROR_CONTROLLER_INVALID, $response->getContent());
+        self::assertStringContainsString('bad', $response->getContent());
     }
 }

--- a/test/Application/RoutingSuccessTest.php
+++ b/test/Application/RoutingSuccessTest.php
@@ -20,12 +20,12 @@ class RoutingSuccessTest extends TestCase
 
         $application->getEventManager()->attach(MvcEvent::EVENT_ROUTE, function ($e) use (&$log): void {
             $match = $e->getRouteMatch();
-            $this->assertInstanceOf(RouteMatch::class, $match, 'Did not receive expected route match');
+            self::assertInstanceOf(RouteMatch::class, $match, 'Did not receive expected route match');
             $log['route-match'] = $match;
         }, -100);
 
         $application->run();
-        $this->assertArrayHasKey('route-match', $log);
-        $this->assertInstanceOf(RouteMatch::class, $log['route-match']);
+        self::assertArrayHasKey('route-match', $log);
+        self::assertInstanceOf(RouteMatch::class, $log['route-match']);
     }
 }

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -115,13 +115,13 @@ class ApplicationTest extends TestCase
     public function testRequestIsPopulatedFromServiceManager(): void
     {
         $request = $this->serviceManager->get('Request');
-        $this->assertSame($request, $this->application->getRequest());
+        self::assertSame($request, $this->application->getRequest());
     }
 
     public function testResponseIsPopulatedFromServiceManager(): void
     {
         $response = $this->serviceManager->get('Response');
-        $this->assertSame($response, $this->application->getResponse());
+        self::assertSame($response, $this->application->getResponse());
     }
 
     public function testEventManagerIsPopulated(): void
@@ -129,9 +129,9 @@ class ApplicationTest extends TestCase
         $events       = $this->serviceManager->get('EventManager');
         $sharedEvents = $events->getSharedManager();
         $appEvents    = $this->application->getEventManager();
-        $this->assertInstanceOf(EventManager::class, $appEvents);
-        $this->assertNotSame($events, $appEvents);
-        $this->assertSame($sharedEvents, $appEvents->getSharedManager());
+        self::assertInstanceOf(EventManager::class, $appEvents);
+        self::assertNotSame($events, $appEvents);
+        self::assertSame($sharedEvents, $appEvents->getSharedManager());
     }
 
     public function testEventManagerListensOnApplicationContext(): void
@@ -139,19 +139,19 @@ class ApplicationTest extends TestCase
         $events      = $this->application->getEventManager();
         $identifiers = $events->getIdentifiers();
         $expected    = [Application::class];
-        $this->assertEquals($expected, array_values($identifiers));
+        self::assertEquals($expected, array_values($identifiers));
     }
 
     public function testServiceManagerIsPopulated(): void
     {
-        $this->assertSame($this->serviceManager, $this->application->getServiceManager());
+        self::assertSame($this->serviceManager, $this->application->getServiceManager());
     }
 
     public function testConfigIsPopulated(): void
     {
         $smConfig  = $this->serviceManager->get('config');
         $appConfig = $this->application->getConfig();
-        $this->assertEquals(
+        self::assertEquals(
             $smConfig,
             $appConfig,
             sprintf('SM config: %s; App config: %s', var_export($smConfig, true), var_export($appConfig, true))
@@ -162,11 +162,11 @@ class ApplicationTest extends TestCase
     {
         $events           = $this->application->getEventManager();
         $registeredEvents = $this->getEventsFromEventManager($events);
-        $this->assertEquals([], $registeredEvents);
+        self::assertEquals([], $registeredEvents);
 
         $sharedEvents = $events->getSharedManager();
-        $this->assertInstanceOf(SharedEventManager::class, $sharedEvents);
-        $this->assertSame([], $this->getIdentifiersFromSharedEventManager($sharedEvents));
+        self::assertInstanceOf(SharedEventManager::class, $sharedEvents);
+        self::assertSame([], $this->getIdentifiersFromSharedEventManager($sharedEvents));
     }
 
     private function getIdentifiersFromSharedEventManager(SharedEventManager $events): array
@@ -190,7 +190,7 @@ class ApplicationTest extends TestCase
         $events = $this->application->getEventManager();
 
         $listeners = $this->getArrayOfListenersForEvent($event, $events);
-        $this->assertContains([$listenerService, $method], $listeners);
+        self::assertContains([$listenerService, $method], $listeners);
     }
 
     public static function bootstrapRegistersListenersProvider(): array
@@ -233,27 +233,27 @@ class ApplicationTest extends TestCase
         }
 
         foreach ($defaultListeners as $defaultListener) {
-            $this->assertContains($defaultListener, $registeredListeners);
+            self::assertContains($defaultListener, $registeredListeners);
         }
     }
 
     public function testBootstrapRegistersConfiguredMvcEvent(): void
     {
-        $this->assertNull($this->application->getMvcEvent());
+        self::assertNull($this->application->getMvcEvent());
         $this->application->bootstrap();
         $event = $this->application->getMvcEvent();
-        $this->assertInstanceOf(MvcEvent::class, $event);
+        self::assertInstanceOf(MvcEvent::class, $event);
 
         $request  = $this->application->getRequest();
         $response = $this->application->getResponse();
         $router   = $this->serviceManager->get('HttpRouter');
 
-        $this->assertFalse($event->isError());
-        $this->assertSame($request, $event->getRequest());
-        $this->assertSame($response, $event->getResponse());
-        $this->assertSame($router, $event->getRouter());
-        $this->assertSame($this->application, $event->getApplication());
-        $this->assertSame($this->application, $event->getTarget());
+        self::assertFalse($event->isError());
+        self::assertSame($request, $event->getRequest());
+        self::assertSame($response, $event->getResponse());
+        self::assertSame($router, $event->getRouter());
+        self::assertSame($this->application, $event->getApplication());
+        self::assertSame($this->application, $event->getTarget());
     }
 
     public function setupPathController(bool $addService = true): ApplicationInterface
@@ -345,7 +345,7 @@ class ApplicationTest extends TestCase
         $application->getEventManager()->attach(MvcEvent::EVENT_FINISH, static fn($e) =>
             $e->getResponse()->setContent($e->getResponse()->getBody() . 'foobar'));
         $application->run();
-        $this->assertStringContainsString(
+        self::assertStringContainsString(
             'foobar',
             $this->application->getResponse()->getBody(),
             'The "finish" event was not triggered ("foobar" not in response)'
@@ -371,8 +371,8 @@ class ApplicationTest extends TestCase
         });
 
         $application->run();
-        $this->assertTrue($event->isError());
-        $this->assertStringContainsString(Application::ERROR_ROUTER_NO_MATCH, $response->getContent());
+        self::assertTrue($event->isError());
+        self::assertStringContainsString(Application::ERROR_ROUTER_NO_MATCH, $response->getContent());
     }
 
     /**
@@ -386,8 +386,8 @@ class ApplicationTest extends TestCase
         $application->getEventManager()->attach(MvcEvent::EVENT_DISPATCH_ERROR, static fn($e): Response => $response);
 
         $result = $application->run();
-        $this->assertSame($application, $result, $result::class);
-        $this->assertSame($response, $result->getResponse(), $result::class);
+        self::assertSame($application, $result, $result::class);
+        self::assertSame($response, $result->getResponse(), $result::class);
     }
 
     /**
@@ -406,7 +406,7 @@ class ApplicationTest extends TestCase
         });
 
         $this->application->run();
-        $this->assertStringContainsString('Raised an error', $response->getContent());
+        self::assertStringContainsString('Raised an error', $response->getContent());
     }
 
     /**
@@ -428,8 +428,8 @@ class ApplicationTest extends TestCase
         });
 
         $application->run();
-        $this->assertTrue($event->isError());
-        $this->assertEquals(Application::ERROR_ROUTER_NO_MATCH, $event->getError());
+        self::assertTrue($event->isError());
+        self::assertEquals(Application::ERROR_ROUTER_NO_MATCH, $event->getError());
     }
 
     /**
@@ -448,8 +448,8 @@ class ApplicationTest extends TestCase
         });
 
         $this->application->run();
-        $this->assertTrue(isset($token->foo));
-        $this->assertEquals('bar', $token->foo);
+        self::assertTrue(isset($token->foo));
+        self::assertEquals('bar', $token->foo);
     }
 
     /**
@@ -469,8 +469,8 @@ class ApplicationTest extends TestCase
         });
 
         $this->application->run();
-        $this->assertTrue(isset($token->foo));
-        $this->assertEquals('bar', $token->foo);
+        self::assertTrue(isset($token->foo));
+        self::assertEquals('bar', $token->foo);
     }
 
     public function testApplicationShouldBeEventTargetAtFinishEvent(): void
@@ -485,7 +485,7 @@ class ApplicationTest extends TestCase
         });
 
         $application->run();
-        $this->assertStringContainsString(Application::class, $response->getContent());
+        self::assertStringContainsString(Application::class, $response->getContent());
     }
 
     public function testOnDispatchErrorEventPassedToTriggersShouldBeTheOriginalOne(): void
@@ -502,7 +502,7 @@ class ApplicationTest extends TestCase
 
         $application->run();
         $event = $application->getMvcEvent();
-        $this->assertInstanceOf(ViewModel::class, $event->getResult());
+        self::assertInstanceOf(ViewModel::class, $event->getResult());
     }
 
     public function testReturnsResponseFromListenerWhenRouteEventShortCircuits(): void
@@ -519,12 +519,12 @@ class ApplicationTest extends TestCase
 
         $triggered = false;
         $events->attach(MvcEvent::EVENT_FINISH, function ($e) use ($testResponse, &$triggered): void {
-            $this->assertSame($testResponse, $e->getResponse());
+            self::assertSame($testResponse, $e->getResponse());
             $triggered = true;
         });
 
         $this->application->run();
-        $this->assertTrue($triggered);
+        self::assertTrue($triggered);
     }
 
     public function testReturnsResponseFromListenerWhenDispatchEventShortCircuits(): void
@@ -541,12 +541,12 @@ class ApplicationTest extends TestCase
 
         $triggered = false;
         $events->attach(MvcEvent::EVENT_FINISH, function ($e) use ($testResponse, &$triggered): void {
-            $this->assertSame($testResponse, $e->getResponse());
+            self::assertSame($testResponse, $e->getResponse());
             $triggered = true;
         });
 
         $this->application->run();
-        $this->assertTrue($triggered);
+        self::assertTrue($triggered);
     }
 
     public function testCompleteRequestShouldReturnApplicationInstance(): void
@@ -557,7 +557,7 @@ class ApplicationTest extends TestCase
         $this->application->bootstrap();
         $event  = $this->application->getMvcEvent();
         $result = $r->invoke($this->application, $event);
-        $this->assertSame($this->application, $result);
+        self::assertSame($this->application, $result);
     }
 
     public function testFailedRoutingShouldBePreventable(): void
@@ -593,7 +593,7 @@ class ApplicationTest extends TestCase
         $this->application->getEventManager()->attach(MvcEvent::EVENT_FINISH, $finishMock, 100);
 
         $this->application->run();
-        $this->assertSame($response, $this->application->getMvcEvent()->getResponse());
+        self::assertSame($response, $this->application->getMvcEvent()->getResponse());
     }
 
     public function testCanRecoverFromApplicationError(): void
@@ -642,7 +642,7 @@ class ApplicationTest extends TestCase
         $this->application->getEventManager()->attach(MvcEvent::EVENT_FINISH, $finishMock, 100);
 
         $this->application->run();
-        $this->assertSame($response, $this->application->getMvcEvent()->getResponse());
+        self::assertSame($response, $this->application->getMvcEvent()->getResponse());
     }
 
     public static function eventPropagation(): array
@@ -688,7 +688,7 @@ class ApplicationTest extends TestCase
         $this->application->run();
 
         foreach ($events as $event) {
-            $this->assertFalse($marker->{$event}, sprintf('Assertion failed for event "%s"', $event));
+            self::assertFalse($marker->{$event}, sprintf('Assertion failed for event "%s"', $event));
         }
     }
 }

--- a/test/Controller/ActionControllerTest.php
+++ b/test/Controller/ActionControllerTest.php
@@ -60,12 +60,12 @@ class ActionControllerTest extends TestCase
     {
         $result   = $this->controller->dispatch($this->request, $this->response);
         $response = $this->controller->getResponse();
-        $this->assertEquals(404, $response->getStatusCode());
-        $this->assertInstanceOf(ModelInterface::class, $result);
-        $this->assertEquals('content', $result->captureTo());
+        self::assertEquals(404, $response->getStatusCode());
+        self::assertInstanceOf(ModelInterface::class, $result);
+        self::assertEquals('content', $result->captureTo());
         $vars = $result->getVariables();
-        $this->assertArrayHasKey('content', $vars, var_export($vars, true));
-        $this->assertStringContainsString('Page not found', $vars['content']);
+        self::assertArrayHasKey('content', $vars, var_export($vars, true));
+        self::assertStringContainsString('Page not found', $vars['content']);
     }
 
     public function testDispatchInvokesNotFoundActionWhenInvalidActionPresentInRouteMatch(): void
@@ -73,28 +73,28 @@ class ActionControllerTest extends TestCase
         $this->routeMatch->setParam('action', 'totally-made-up-action');
         $result   = $this->controller->dispatch($this->request, $this->response);
         $response = $this->controller->getResponse();
-        $this->assertEquals(404, $response->getStatusCode());
-        $this->assertInstanceOf(ModelInterface::class, $result);
-        $this->assertEquals('content', $result->captureTo());
+        self::assertEquals(404, $response->getStatusCode());
+        self::assertInstanceOf(ModelInterface::class, $result);
+        self::assertEquals('content', $result->captureTo());
         $vars = $result->getVariables();
-        $this->assertArrayHasKey('content', $vars, var_export($vars, true));
-        $this->assertStringContainsString('Page not found', $vars['content']);
+        self::assertArrayHasKey('content', $vars, var_export($vars, true));
+        self::assertStringContainsString('Page not found', $vars['content']);
     }
 
     public function testDispatchInvokesProvidedActionWhenMethodExists(): void
     {
         $this->routeMatch->setParam('action', 'test');
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertTrue(isset($result['content']));
-        $this->assertStringContainsString('test', $result['content']);
+        self::assertTrue(isset($result['content']));
+        self::assertStringContainsString('test', $result['content']);
     }
 
     public function testDispatchCallsActionMethodBasedOnNormalizingAction(): void
     {
         $this->routeMatch->setParam('action', 'test.some-strangely_separated.words');
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertTrue(isset($result['content']));
-        $this->assertStringContainsString('Test Some Strangely Separated Words', $result['content']);
+        self::assertTrue(isset($result['content']));
+        self::assertStringContainsString('Test Some Strangely Separated Words', $result['content']);
     }
 
     public function testShortCircuitsBeforeActionIfPreDispatchReturnsAResponse(): void
@@ -107,7 +107,7 @@ class ActionControllerTest extends TestCase
             100
         );
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertSame($response, $result);
+        self::assertSame($response, $result);
     }
 
     public function testPostDispatchEventAllowsReplacingResponse(): void
@@ -120,7 +120,7 @@ class ActionControllerTest extends TestCase
             -10
         );
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertSame($response, $result);
+        self::assertSame($response, $result);
     }
 
     public function testEventManagerListensOnDispatchableInterfaceByDefault(): void
@@ -135,7 +135,7 @@ class ActionControllerTest extends TestCase
             10
         );
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertSame($response, $result);
+        self::assertSame($response, $result);
     }
 
     public function testEventManagerListensOnActionControllerClassByDefault(): void
@@ -150,7 +150,7 @@ class ActionControllerTest extends TestCase
             10
         );
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertSame($response, $result);
+        self::assertSame($response, $result);
     }
 
     public function testEventManagerListensOnClassNameByDefault(): void
@@ -165,7 +165,7 @@ class ActionControllerTest extends TestCase
             10
         );
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertSame($response, $result);
+        self::assertSame($response, $result);
     }
 
     public function testEventManagerListensOnInterfaceName(): void
@@ -180,59 +180,59 @@ class ActionControllerTest extends TestCase
             10
         );
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertSame($response, $result);
+        self::assertSame($response, $result);
     }
 
     public function testDispatchInjectsEventIntoController(): void
     {
         $this->controller->dispatch($this->request, $this->response);
         $event = $this->controller->getEvent();
-        $this->assertNotNull($event);
-        $this->assertSame($this->event, $event);
+        self::assertNotNull($event);
+        self::assertSame($this->event, $event);
     }
 
     public function testControllerIsEventAware(): void
     {
-        $this->assertInstanceOf(InjectApplicationEventInterface::class, $this->controller);
+        self::assertInstanceOf(InjectApplicationEventInterface::class, $this->controller);
     }
 
     public function testControllerIsPluggable(): void
     {
-        $this->assertTrue(method_exists($this->controller, 'plugin'));
+        self::assertTrue(method_exists($this->controller, 'plugin'));
     }
 
     public function testComposesPluginManagerByDefault(): void
     {
         $plugins = $this->controller->getPluginManager();
-        $this->assertInstanceOf(PluginManager::class, $plugins);
+        self::assertInstanceOf(PluginManager::class, $plugins);
     }
 
     public function testPluginManagerComposesController(): void
     {
         $plugins    = $this->controller->getPluginManager();
         $controller = $plugins->getController();
-        $this->assertSame($this->controller, $controller);
+        self::assertSame($this->controller, $controller);
     }
 
     public function testInjectingPluginManagerSetsControllerWhenPossible(): void
     {
         $plugins = new PluginManager(new ServiceManager());
-        $this->assertNull($plugins->getController());
+        self::assertNull($plugins->getController());
         $this->controller->setPluginManager($plugins);
-        $this->assertSame($this->controller, $plugins->getController());
-        $this->assertSame($plugins, $this->controller->getPluginManager());
+        self::assertSame($this->controller, $plugins->getController());
+        self::assertSame($plugins, $this->controller->getPluginManager());
     }
 
     public function testMethodOverloadingShouldReturnPluginWhenFound(): void
     {
         $plugin = $this->controller->url();
-        $this->assertInstanceOf(Url::class, $plugin);
+        self::assertInstanceOf(Url::class, $plugin);
     }
 
     public function testMethodOverloadingShouldInvokePluginAsFunctorIfPossible(): void
     {
         $model = $this->event->getViewModel();
         $this->controller->layout('alternate/layout');
-        $this->assertEquals('alternate/layout', $model->getTemplate());
+        self::assertEquals('alternate/layout', $model->getTemplate());
     }
 }

--- a/test/Controller/ControllerManagerTest.php
+++ b/test/Controller/ControllerManagerTest.php
@@ -58,8 +58,8 @@ class ControllerManagerTest extends TestCase
         // instance, which means we need to check that that instance gets injected
         // with the shared EM instance.
         $events = $controller->getEventManager();
-        $this->assertInstanceOf(EventManagerInterface::class, $events);
-        $this->assertSame($this->sharedEvents, $events->getSharedManager());
+        self::assertInstanceOf(EventManagerInterface::class, $events);
+        self::assertSame($this->sharedEvents, $events->getSharedManager());
     }
 
     public function testCanInjectPluginManager()
@@ -68,7 +68,7 @@ class ControllerManagerTest extends TestCase
 
         $this->controllers->injectPluginManager($this->services, $controller);
 
-        $this->assertSame($this->services->get('ControllerPluginManager'), $controller->getPluginManager());
+        self::assertSame($this->services->get('ControllerPluginManager'), $controller->getPluginManager());
     }
 
     public function testInjectEventManagerWillNotOverwriteExistingEventManagerIfItAlreadyHasASharedManager()
@@ -79,8 +79,8 @@ class ControllerManagerTest extends TestCase
 
         $this->controllers->injectEventManager($this->services, $controller);
 
-        $this->assertSame($events, $controller->getEventManager());
-        $this->assertSame($this->sharedEvents, $events->getSharedManager());
+        self::assertSame($events, $controller->getEventManager());
+        self::assertSame($this->sharedEvents, $events->getSharedManager());
     }
 
     /**
@@ -89,7 +89,7 @@ class ControllerManagerTest extends TestCase
      */
     public function testDoNotUsePeeringServiceManagers()
     {
-        $this->assertFalse($this->controllers->has('EventManager'));
+        self::assertFalse($this->controllers->has('EventManager'));
         $this->expectException(ServiceNotFoundException::class);
         $this->controllers->get('EventManager');
     }

--- a/test/Controller/IntegrationTest.php
+++ b/test/Controller/IntegrationTest.php
@@ -48,14 +48,14 @@ class IntegrationTest extends TestCase
 
         $first  = $controllers->get('first');
         $second = $controllers->get('second');
-        $this->assertNotSame($first, $second);
+        self::assertNotSame($first, $second);
 
         $plugin1 = $first->plugin('url');
-        $this->assertSame($first, $plugin1->getController());
+        self::assertSame($first, $plugin1->getController());
 
         $plugin2 = $second->plugin('url');
-        $this->assertSame($second, $plugin2->getController());
+        self::assertSame($second, $plugin2->getController());
 
-        $this->assertSame($plugin1, $plugin2);
+        self::assertSame($plugin1, $plugin2);
     }
 }

--- a/test/Controller/LazyControllerAbstractFactoryTest.php
+++ b/test/Controller/LazyControllerAbstractFactoryTest.php
@@ -45,27 +45,27 @@ class LazyControllerAbstractFactoryTest extends TestCase
     public function testCanCreateReturnsFalseForNonClassRequestedNames(string $requestedName): void
     {
         $factory = new LazyControllerAbstractFactory();
-        $this->assertFalse($factory->canCreate($this->container, $requestedName));
+        self::assertFalse($factory->canCreate($this->container, $requestedName));
     }
 
     public function testCanCreateReturnsFalseForClassesThatDoNotImplementDispatchableInterface(): void
     {
         $factory = new LazyControllerAbstractFactory();
-        $this->assertFalse($factory->canCreate($this->container, self::class));
+        self::assertFalse($factory->canCreate($this->container, self::class));
     }
 
     public function testFactoryInstantiatesClassDirectlyIfItHasNoConstructor(): void
     {
         $factory    = new LazyControllerAbstractFactory();
         $controller = $factory($this->container, SampleController::class);
-        $this->assertInstanceOf(SampleController::class, $controller);
+        self::assertInstanceOf(SampleController::class, $controller);
     }
 
     public function testFactoryInstantiatesClassDirectlyIfConstructorHasNoArguments(): void
     {
         $factory    = new LazyControllerAbstractFactory();
         $controller = $factory($this->container, ControllerWithEmptyConstructor::class);
-        $this->assertInstanceOf(ControllerWithEmptyConstructor::class, $controller);
+        self::assertInstanceOf(ControllerWithEmptyConstructor::class, $controller);
     }
 
     public function testFactoryRaisesExceptionWhenUnableToResolveATypeHintedService(): void
@@ -107,9 +107,9 @@ class LazyControllerAbstractFactoryTest extends TestCase
     {
         $factory    = new LazyControllerAbstractFactory();
         $controller = $factory($this->container, ControllerWithScalarParameters::class);
-        $this->assertInstanceOf(ControllerWithScalarParameters::class, $controller);
-        $this->assertNull($controller->foo);
-        $this->assertNull($controller->bar);
+        self::assertInstanceOf(ControllerWithScalarParameters::class, $controller);
+        self::assertNull($controller->foo);
+        self::assertNull($controller->bar);
     }
 
     public function testFactoryInjectsConfigServiceForConfigArgumentsTypeHintedAsArray(): void
@@ -120,8 +120,8 @@ class LazyControllerAbstractFactoryTest extends TestCase
 
         $factory    = new LazyControllerAbstractFactory();
         $controller = $factory($this->container, ControllerAcceptingConfigToConstructor::class);
-        $this->assertInstanceOf(ControllerAcceptingConfigToConstructor::class, $controller);
-        $this->assertEquals($config, $controller->config);
+        self::assertInstanceOf(ControllerAcceptingConfigToConstructor::class, $controller);
+        self::assertEquals($config, $controller->config);
     }
 
     public function testFactoryCanInjectKnownTypeHintedServices(): void
@@ -135,8 +135,8 @@ class LazyControllerAbstractFactoryTest extends TestCase
             $this->container,
             ControllerWithTypeHintedConstructorParameter::class
         );
-        $this->assertInstanceOf(ControllerWithTypeHintedConstructorParameter::class, $controller);
-        $this->assertSame($sample, $controller->sample);
+        self::assertInstanceOf(ControllerWithTypeHintedConstructorParameter::class, $controller);
+        self::assertSame($sample, $controller->sample);
     }
 
     public function testFactoryResolvesTypeHintsForServicesToWellKnownServiceNames(): void
@@ -150,11 +150,11 @@ class LazyControllerAbstractFactoryTest extends TestCase
             $this->container,
             ControllerAcceptingWellKnownServicesAsConstructorParameters::class
         );
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             ControllerAcceptingWellKnownServicesAsConstructorParameters::class,
             $controller
         );
-        $this->assertSame($validators, $controller->validators);
+        self::assertSame($validators, $controller->validators);
     }
 
     public function testFactoryCanSupplyAMixOfParameterTypes(): void
@@ -173,12 +173,12 @@ class LazyControllerAbstractFactoryTest extends TestCase
 
         $factory    = new LazyControllerAbstractFactory();
         $controller = $factory($this->container, ControllerWithMixedConstructorParameters::class);
-        $this->assertInstanceOf(ControllerWithMixedConstructorParameters::class, $controller);
+        self::assertInstanceOf(ControllerWithMixedConstructorParameters::class, $controller);
 
-        $this->assertEquals(['foo' => 'bar'], $controller->config);
-        $this->assertNull($controller->foo);
-        $this->assertEquals([], $controller->options);
-        $this->assertInstanceOf(SampleInterface::class, $controller->sample);
-        $this->assertInstanceOf(ValidatorPluginManager::class, $controller->validators);
+        self::assertEquals(['foo' => 'bar'], $controller->config);
+        self::assertNull($controller->foo);
+        self::assertEquals([], $controller->options);
+        self::assertInstanceOf(SampleInterface::class, $controller->sample);
+        self::assertInstanceOf(ValidatorPluginManager::class, $controller->validators);
     }
 }

--- a/test/Controller/Plugin/AcceptableViewModelSelectorTest.php
+++ b/test/Controller/Plugin/AcceptableViewModelSelectorTest.php
@@ -59,9 +59,9 @@ class AcceptableViewModelSelectorTest extends TestCase
         $plugin->setDefaultViewModelName(FeedModel::class);
         $result = $plugin($arr);
 
-        $this->assertInstanceOf(ViewModel::class, $result);
-        $this->assertNotInstanceOf(FeedModel::class, $result); // Ensure the default wasn't selected
-        $this->assertNotInstanceOf(JsonModel::class, $result);
+        self::assertInstanceOf(ViewModel::class, $result);
+        self::assertNotInstanceOf(FeedModel::class, $result); // Ensure the default wasn't selected
+        self::assertNotInstanceOf(JsonModel::class, $result);
     }
 
     public function testDefaultViewModelName(): void
@@ -82,11 +82,11 @@ class AcceptableViewModelSelectorTest extends TestCase
         $plugin = $this->plugin;
         $result = $plugin->getViewModelName($arr);
 
-        $this->assertEquals(ViewModel::class, $result); //   Default Default View Model Name
+        self::assertEquals(ViewModel::class, $result); //   Default Default View Model Name
 
         $plugin->setDefaultViewModelName(FeedModel::class);
-        $this->assertEquals($plugin->getDefaultViewModelName(), FeedModel::class); // Test getter along the way
-        $this->assertInstanceOf(FeedModel::class, $plugin($arr));
+        self::assertEquals($plugin->getDefaultViewModelName(), FeedModel::class); // Test getter along the way
+        self::assertInstanceOf(FeedModel::class, $plugin($arr));
     }
 
     public function testSelectsViewModelBasedOnAcceptHeaderWhenInvokedAsFunctor(): void
@@ -108,7 +108,7 @@ class AcceptableViewModelSelectorTest extends TestCase
         $this->request->getHeaders()->addHeader($header);
         $result = $plugin($arr);
 
-        $this->assertInstanceOf(FeedModel::class, $result);
+        self::assertInstanceOf(FeedModel::class, $result);
     }
 
     public function testInvokeWithoutDefaultsReturnsNullWhenNoMatchesOccur(): void
@@ -129,7 +129,7 @@ class AcceptableViewModelSelectorTest extends TestCase
         $this->request->getHeaders()->addHeader($header);
 
         $result = $plugin($arr, false);
-        $this->assertNull($result);
+        self::assertNull($result);
     }
 
     public function testInvokeReturnsFieldValuePartOnMatchWhenReferenceProvided(): void
@@ -140,10 +140,10 @@ class AcceptableViewModelSelectorTest extends TestCase
 
         $ref    = null;
         $result = $plugin([ViewModel::class => '*/*'], false, $ref);
-        $this->assertInstanceOf(ViewModel::class, $result);
-        $this->assertNotInstanceOf(JsonModel::class, $result);
-        $this->assertNotInstanceOf(FeedModel::class, $result);
-        $this->assertInstanceOf(AcceptFieldValuePart::class, $ref);
+        self::assertInstanceOf(ViewModel::class, $result);
+        self::assertNotInstanceOf(JsonModel::class, $result);
+        self::assertNotInstanceOf(FeedModel::class, $result);
+        self::assertInstanceOf(AcceptFieldValuePart::class, $ref);
     }
 
     public function testGetViewModelNameWithoutDefaults(): void
@@ -164,12 +164,12 @@ class AcceptableViewModelSelectorTest extends TestCase
         $this->request->getHeaders()->addHeader($header);
 
         $result = $plugin->getViewModelName($arr, false);
-        $this->assertNull($result);
+        self::assertNull($result);
 
         $ref    = null;
         $result = $plugin->getViewModelName([ViewModel::class => '*/*'], false, $ref);
-        $this->assertEquals(ViewModel::class, $result);
-        $this->assertInstanceOf(AcceptFieldValuePart::class, $ref);
+        self::assertEquals(ViewModel::class, $result);
+        self::assertInstanceOf(AcceptFieldValuePart::class, $ref);
     }
 
     public function testMatch(): void
@@ -180,10 +180,10 @@ class AcceptableViewModelSelectorTest extends TestCase
 
         $arr = [ViewModel::class => '*/*'];
         $plugin->setDefaultMatchAgainst($arr);
-        $this->assertEquals($plugin->getDefaultMatchAgainst(), $arr);
+        self::assertEquals($plugin->getDefaultMatchAgainst(), $arr);
         $result = $plugin->match();
-        $this->assertInstanceOf(AcceptFieldValuePart::class, $result);
-        $this->assertEquals($plugin->getDefaultMatchAgainst(), $arr);
+        self::assertInstanceOf(AcceptFieldValuePart::class, $result);
+        self::assertEquals($plugin->getDefaultMatchAgainst(), $arr);
     }
 
     public function testInvalidModel(): void

--- a/test/Controller/Plugin/CreateHttpNotFoundModelTest.php
+++ b/test/Controller/Plugin/CreateHttpNotFoundModelTest.php
@@ -23,8 +23,8 @@ class CreateHttpNotFoundModelTest extends TestCase
 
         $model = $plugin->__invoke($response);
 
-        $this->assertInstanceOf(ViewModel::class, $model);
-        $this->assertSame('Page not found', $model->getVariable('content'));
-        $this->assertSame(404, $response->getStatusCode());
+        self::assertInstanceOf(ViewModel::class, $model);
+        self::assertSame('Page not found', $model->getVariable('content'));
+        self::assertSame(404, $response->getStatusCode());
     }
 }

--- a/test/Controller/Plugin/ForwardTest.php
+++ b/test/Controller/Plugin/ForwardTest.php
@@ -179,8 +179,8 @@ class ForwardTest extends TestCase
     public function testPluginDispatchsRequestedControllerWhenFound(): void
     {
         $result = $this->plugin->dispatch('forward');
-        $this->assertIsArray($result);
-        $this->assertEquals(
+        self::assertIsArray($result);
+        self::assertEquals(
             ['content' => 'LaminasTest\Mvc\Controller\TestAsset\ForwardController::testAction'],
             $result
         );
@@ -204,8 +204,8 @@ class ForwardTest extends TestCase
         $event->setApplication($application);
 
         $result = $this->plugin->dispatch('forward');
-        $this->assertIsArray($result);
-        $this->assertEquals(
+        self::assertIsArray($result);
+        self::assertEquals(
             ['content' => 'LaminasTest\Mvc\Controller\TestAsset\ForwardController::testAction'],
             $result
         );
@@ -287,11 +287,11 @@ class ForwardTest extends TestCase
             'action' => 'test-matches',
             'param1' => 'foobar',
         ]);
-        $this->assertIsArray($result);
-        $this->assertTrue(isset($result['action']));
-        $this->assertEquals('test-matches', $result['action']);
-        $this->assertTrue(isset($result['param1']));
-        $this->assertEquals('foobar', $result['param1']);
+        self::assertIsArray($result);
+        self::assertTrue(isset($result['action']));
+        self::assertEquals('test-matches', $result['action']);
+        self::assertTrue(isset($result['param1']));
+        self::assertEquals('foobar', $result['param1']);
     }
 
     public function testRouteMatchObjectRemainsSameFollowingForwardDispatch(): void
@@ -307,19 +307,19 @@ class ForwardTest extends TestCase
         $testParams            = $testMatch->getParams();
         $testMatchedRouteName  = $testMatch->getMatchedRouteName();
 
-        $this->assertSame($routeMatch, $testMatch);
-        $this->assertEquals($matchParams, $testParams);
-        $this->assertEquals($matchMatchedRouteName, $testMatchedRouteName);
+        self::assertSame($routeMatch, $testMatch);
+        self::assertEquals($matchParams, $testParams);
+        self::assertEquals($matchMatchedRouteName, $testMatchedRouteName);
     }
 
     public function testAllowsPassingEmptyArrayOfRouteParams(): void
     {
         $result = $this->plugin->dispatch('forward', []);
-        $this->assertIsArray($result);
-        $this->assertTrue(isset($result['status']));
-        $this->assertEquals('not-found', $result['status']);
-        $this->assertTrue(isset($result['params']));
-        $this->assertEquals([], $result['params']);
+        self::assertIsArray($result);
+        self::assertTrue(isset($result['status']));
+        self::assertEquals('not-found', $result['status']);
+        self::assertTrue(isset($result['params']));
+        self::assertEquals([], $result['params']);
     }
 
     /**
@@ -327,6 +327,6 @@ class ForwardTest extends TestCase
      */
     public function testSetListenersToDetachIsFluent(): void
     {
-        $this->assertSame($this->plugin, $this->plugin->setListenersToDetach([]));
+        self::assertSame($this->plugin, $this->plugin->setListenersToDetach([]));
     }
 }

--- a/test/Controller/Plugin/LayoutTest.php
+++ b/test/Controller/Plugin/LayoutTest.php
@@ -41,7 +41,7 @@ class LayoutTest extends TestCase
         $this->event->setViewModel($model);
 
         $this->plugin->setTemplate('alternate/layout');
-        $this->assertEquals('alternate/layout', $model->getTemplate());
+        self::assertEquals('alternate/layout', $model->getTemplate());
     }
 
     public function testInvokeProxiesToSetTemplate(): void
@@ -52,7 +52,7 @@ class LayoutTest extends TestCase
 
         $plugin = $this->plugin;
         $plugin('alternate/layout');
-        $this->assertEquals('alternate/layout', $model->getTemplate());
+        self::assertEquals('alternate/layout', $model->getTemplate());
     }
 
     public function testCallingInvokeWithNoArgumentsReturnsViewModel(): void
@@ -63,6 +63,6 @@ class LayoutTest extends TestCase
 
         $plugin = $this->plugin;
         $result = $plugin();
-        $this->assertSame($model, $result);
+        self::assertSame($model, $result);
     }
 }

--- a/test/Controller/Plugin/ParamsTest.php
+++ b/test/Controller/Plugin/ParamsTest.php
@@ -44,31 +44,31 @@ class ParamsTest extends TestCase
     public function testFromRouteIsDefault(): void
     {
         $value = $this->plugin->__invoke('value');
-        $this->assertEquals($value, 'rm:1234');
+        self::assertEquals($value, 'rm:1234');
     }
 
     public function testFromRouteReturnsDefaultIfSet(): void
     {
         $value = $this->plugin->fromRoute('foo', 'bar');
-        $this->assertEquals($value, 'bar');
+        self::assertEquals($value, 'bar');
     }
 
     public function testFromRouteReturnsExpectedValue(): void
     {
         $value = $this->plugin->fromRoute('value');
-        $this->assertEquals($value, 'rm:1234');
+        self::assertEquals($value, 'rm:1234');
     }
 
     public function testFromRouteNotReturnsExpectedValueWithDefault(): void
     {
         $value = $this->plugin->fromRoute('value', 'default');
-        $this->assertEquals($value, 'rm:1234');
+        self::assertEquals($value, 'rm:1234');
     }
 
     public function testFromRouteReturnsAllIfEmpty(): void
     {
         $value = $this->plugin->fromRoute();
-        $this->assertEquals($value, ['value' => 'rm:1234', 'other' => '1234:rm']);
+        self::assertEquals($value, ['value' => 'rm:1234', 'other' => '1234:rm']);
     }
 
     public function testFromQueryReturnsDefaultIfSet(): void
@@ -76,7 +76,7 @@ class ParamsTest extends TestCase
         $this->setQuery();
 
         $value = $this->plugin->fromQuery('foo', 'bar');
-        $this->assertEquals($value, 'bar');
+        self::assertEquals($value, 'bar');
     }
 
     public function testFromQueryReturnsExpectedValue(): void
@@ -84,7 +84,7 @@ class ParamsTest extends TestCase
         $this->setQuery();
 
         $value = $this->plugin->fromQuery('value');
-        $this->assertEquals($value, 'query:1234');
+        self::assertEquals($value, 'query:1234');
     }
 
     public function testFromQueryReturnsExpectedValueWithDefault(): void
@@ -92,7 +92,7 @@ class ParamsTest extends TestCase
         $this->setQuery();
 
         $value = $this->plugin->fromQuery('value', 'default');
-        $this->assertEquals($value, 'query:1234');
+        self::assertEquals($value, 'query:1234');
     }
 
     public function testFromQueryReturnsAllIfEmpty(): void
@@ -100,7 +100,7 @@ class ParamsTest extends TestCase
         $this->setQuery();
 
         $value = $this->plugin->fromQuery();
-        $this->assertEquals($value, ['value' => 'query:1234', 'other' => '1234:other']);
+        self::assertEquals($value, ['value' => 'query:1234', 'other' => '1234:other']);
     }
 
     public function testFromPostReturnsDefaultIfSet(): void
@@ -108,7 +108,7 @@ class ParamsTest extends TestCase
         $this->setPost();
 
         $value = $this->plugin->fromPost('foo', 'bar');
-        $this->assertEquals($value, 'bar');
+        self::assertEquals($value, 'bar');
     }
 
     public function testFromPostReturnsExpectedValue(): void
@@ -116,7 +116,7 @@ class ParamsTest extends TestCase
         $this->setPost();
 
         $value = $this->plugin->fromPost('value');
-        $this->assertEquals($value, 'post:1234');
+        self::assertEquals($value, 'post:1234');
     }
 
     public function testFromPostReturnsExpectedValueWithDefault(): void
@@ -124,7 +124,7 @@ class ParamsTest extends TestCase
         $this->setPost();
 
         $value = $this->plugin->fromPost('value', 'default');
-        $this->assertEquals($value, 'post:1234');
+        self::assertEquals($value, 'post:1234');
     }
 
     public function testFromPostReturnsAllIfEmpty(): void
@@ -132,7 +132,7 @@ class ParamsTest extends TestCase
         $this->setPost();
 
         $value = $this->plugin->fromPost();
-        $this->assertEquals($value, ['value' => 'post:1234', 'other' => '2345:other']);
+        self::assertEquals($value, ['value' => 'post:1234', 'other' => '2345:other']);
     }
 
     public function testFromFilesReturnsExpectedValue(): void
@@ -148,7 +148,7 @@ class ParamsTest extends TestCase
         $this->controller->dispatch($this->request);
 
         $value = $this->plugin->fromFiles('test');
-        $this->assertEquals($value, $file);
+        self::assertEquals($value, $file);
     }
 
     public function testFromFilesReturnsAllIfEmpty(): void
@@ -173,7 +173,7 @@ class ParamsTest extends TestCase
         $this->controller->dispatch($this->request);
 
         $value = $this->plugin->fromFiles();
-        $this->assertEquals($value, ['file' => $file, 'file2' => $file2]);
+        self::assertEquals($value, ['file' => $file, 'file2' => $file2]);
     }
 
     public function testFromHeaderReturnsExpectedValue(): void
@@ -183,7 +183,7 @@ class ParamsTest extends TestCase
         $this->controller->dispatch($this->request);
 
         $value = $this->plugin->fromHeader('X-TEST');
-        $this->assertSame($value, $header);
+        self::assertSame($value, $header);
     }
 
     public function testFromHeaderReturnsAllIfEmpty(): void
@@ -197,12 +197,12 @@ class ParamsTest extends TestCase
         $this->controller->dispatch($this->request);
 
         $value = $this->plugin->fromHeader();
-        $this->assertSame($value, ['X-TEST' => 'test', 'OTHER-TEST' => 'value:12345']);
+        self::assertSame($value, ['X-TEST' => 'test', 'OTHER-TEST' => 'value:12345']);
     }
 
     public function testInvokeWithNoArgumentsReturnsInstance(): void
     {
-        $this->assertSame($this->plugin, $this->plugin->__invoke());
+        self::assertSame($this->plugin, $this->plugin->__invoke());
     }
 
     protected function setQuery(): void

--- a/test/Controller/Plugin/RedirectTest.php
+++ b/test/Controller/Plugin/RedirectTest.php
@@ -56,19 +56,19 @@ class RedirectTest extends TestCase
     public function testPluginCanRedirectToRouteWhenProperlyConfigured(): void
     {
         $response = $this->plugin->toRoute('home');
-        $this->assertTrue($response->isRedirect());
+        self::assertTrue($response->isRedirect());
         $headers  = $response->getHeaders();
         $location = $headers->get('Location');
-        $this->assertEquals('/', $location->getFieldValue());
+        self::assertEquals('/', $location->getFieldValue());
     }
 
     public function testPluginCanRedirectToUrlWhenProperlyConfigured(): void
     {
         $response = $this->plugin->toUrl('/foo');
-        $this->assertTrue($response->isRedirect());
+        self::assertTrue($response->isRedirect());
         $headers  = $response->getHeaders();
         $location = $headers->get('Location');
-        $this->assertEquals('/foo', $location->getFieldValue());
+        self::assertEquals('/foo', $location->getFieldValue());
     }
 
     public function testPluginWithoutControllerRaisesDomainException(): void
@@ -126,7 +126,7 @@ class RedirectTest extends TestCase
         $response = $this->plugin->toRoute();
         $headers  = $response->getHeaders();
         $location = $headers->get('Location');
-        $this->assertEquals('/', $location->getFieldValue());
+        self::assertEquals('/', $location->getFieldValue());
     }
 
     public function testCanReuseMatchedParameters(): void
@@ -145,7 +145,7 @@ class RedirectTest extends TestCase
         $response = $this->plugin->toRoute('replace', ['action' => 'bar'], [], true);
         $headers  = $response->getHeaders();
         $location = $headers->get('Location');
-        $this->assertEquals('/foo/bar', $location->getFieldValue());
+        self::assertEquals('/foo/bar', $location->getFieldValue());
     }
 
     public function testCanPassBooleanValueForThirdArgumentToAllowReusingRouteMatches(): void
@@ -164,26 +164,26 @@ class RedirectTest extends TestCase
         $response = $this->plugin->toRoute('replace', ['action' => 'bar'], true);
         $headers  = $response->getHeaders();
         $location = $headers->get('Location');
-        $this->assertEquals('/foo/bar', $location->getFieldValue());
+        self::assertEquals('/foo/bar', $location->getFieldValue());
     }
 
     public function testPluginCanRefreshToRouteWhenProperlyConfigured(): void
     {
         $this->event->setRouteMatch($this->routeMatch);
         $response = $this->plugin->refresh();
-        $this->assertTrue($response->isRedirect());
+        self::assertTrue($response->isRedirect());
         $headers  = $response->getHeaders();
         $location = $headers->get('Location');
-        $this->assertEquals('/', $location->getFieldValue());
+        self::assertEquals('/', $location->getFieldValue());
     }
 
     public function testPluginCanRedirectToRouteWithNullWhenProperlyConfigured(): void
     {
         $this->event->setRouteMatch($this->routeMatch);
         $response = $this->plugin->toRoute();
-        $this->assertTrue($response->isRedirect());
+        self::assertTrue($response->isRedirect());
         $headers  = $response->getHeaders();
         $location = $headers->get('Location');
-        $this->assertEquals('/', $location->getFieldValue());
+        self::assertEquals('/', $location->getFieldValue());
     }
 }

--- a/test/Controller/Plugin/UrlTest.php
+++ b/test/Controller/Plugin/UrlTest.php
@@ -55,7 +55,7 @@ class UrlTest extends TestCase
     public function testPluginCanGenerateUrlWhenProperlyConfigured(): void
     {
         $url = $this->plugin->fromRoute('home');
-        $this->assertEquals('/', $url);
+        self::assertEquals('/', $url);
     }
 
     public function testModel(): void
@@ -63,7 +63,7 @@ class UrlTest extends TestCase
         $it = new ArrayIterator(['controller' => 'ctrl', 'action' => 'act']);
 
         $url = $this->plugin->fromRoute('default', $it);
-        $this->assertEquals('/ctrl/act', $url);
+        self::assertEquals('/ctrl/act', $url);
     }
 
     public function testPluginWithoutControllerRaisesDomainException(): void
@@ -116,7 +116,7 @@ class UrlTest extends TestCase
         $routeMatch->setMatchedRouteName('home');
         $this->controller->getEvent()->setRouteMatch($routeMatch);
         $url = $this->plugin->fromRoute();
-        $this->assertEquals('/', $url);
+        self::assertEquals('/', $url);
     }
 
     public function testCanReuseMatchedParameters(): void
@@ -133,7 +133,7 @@ class UrlTest extends TestCase
         $routeMatch->setMatchedRouteName('replace');
         $this->controller->getEvent()->setRouteMatch($routeMatch);
         $url = $this->plugin->fromRoute('replace', ['action' => 'bar'], [], true);
-        $this->assertEquals('/foo/bar', $url);
+        self::assertEquals('/foo/bar', $url);
     }
 
     public function testCanPassBooleanValueForThirdArgumentToAllowReusingRouteMatches(): void
@@ -150,7 +150,7 @@ class UrlTest extends TestCase
         $routeMatch->setMatchedRouteName('replace');
         $this->controller->getEvent()->setRouteMatch($routeMatch);
         $url = $this->plugin->fromRoute('replace', ['action' => 'bar'], true);
-        $this->assertEquals('/foo/bar', $url);
+        self::assertEquals('/foo/bar', $url);
     }
 
     public function testRemovesModuleRouteListenerParamsWhenReusingMatchedParameters(): void
@@ -194,6 +194,6 @@ class UrlTest extends TestCase
         $controller->setEvent($event);
         $url = $controller->plugin('url')->fromRoute('default/wildcard', ['Twenty' => 'Cooler'], true);
 
-        $this->assertEquals('/Rainbow/Dash=Twenty%Cooler', $url);
+        self::assertEquals('/Rainbow/Dash=Twenty%Cooler', $url);
     }
 }

--- a/test/Controller/PluginManagerTest.php
+++ b/test/Controller/PluginManagerTest.php
@@ -26,7 +26,7 @@ class PluginManagerTest extends TestCase
         $pluginManager->setController($controller);
 
         $plugin = $pluginManager->get('samplePlugin');
-        $this->assertEquals($controller, $plugin->getController());
+        self::assertEquals($controller, $plugin->getController());
     }
 
     public function testPluginManagerInjectsControllerForExistingPlugin()
@@ -45,7 +45,7 @@ class PluginManagerTest extends TestCase
         $pluginManager->setController($controller2);
 
         $plugin = $pluginManager->get('samplePlugin');
-        $this->assertEquals($controller2, $plugin->getController());
+        self::assertEquals($controller2, $plugin->getController());
     }
 
     public function testGetWithConstructor()
@@ -55,7 +55,7 @@ class PluginManagerTest extends TestCase
             'factories' => [SamplePluginWithConstructor::class => InvokableFactory::class],
         ]);
         $plugin        = $pluginManager->get('samplePlugin');
-        $this->assertEquals($plugin->getBar(), 'baz');
+        self::assertEquals($plugin->getBar(), 'baz');
     }
 
     public function testGetWithConstructorAndOptions()
@@ -65,7 +65,7 @@ class PluginManagerTest extends TestCase
             'factories' => [SamplePluginWithConstructor::class => InvokableFactory::class],
         ]);
         $plugin        = $pluginManager->get('samplePlugin', ['foo']);
-        $this->assertEquals($plugin->getBar(), ['foo']);
+        self::assertEquals($plugin->getBar(), ['foo']);
     }
 
     public function testCanCreateByFactory()
@@ -76,7 +76,7 @@ class PluginManagerTest extends TestCase
             ],
         ]);
         $plugin        = $pluginManager->get('samplePlugin');
-        $this->assertInstanceOf(SamplePlugin::class, $plugin);
+        self::assertInstanceOf(SamplePlugin::class, $plugin);
     }
 
     public function testCanCreateByFactoryWithConstrutor()
@@ -87,7 +87,7 @@ class PluginManagerTest extends TestCase
             ],
         ]);
         $plugin        = $pluginManager->get('samplePlugin', ['foo']);
-        $this->assertInstanceOf(SamplePluginWithConstructor::class, $plugin);
-        $this->assertEquals($plugin->getBar(), ['foo']);
+        self::assertInstanceOf(SamplePluginWithConstructor::class, $plugin);
+        self::assertEquals($plugin->getBar(), ['foo']);
     }
 }

--- a/test/Controller/RestfulControllerTest.php
+++ b/test/Controller/RestfulControllerTest.php
@@ -71,9 +71,9 @@ class RestfulControllerTest extends TestCase
         ];
         $this->controller->entities = $entities;
         $result                     = $this->controller->dispatch($this->request, $this->response);
-        $this->assertArrayHasKey('entities', $result);
-        $this->assertEquals($entities, $result['entities']);
-        $this->assertEquals('getList', $this->routeMatch->getParam('action'));
+        self::assertArrayHasKey('entities', $result);
+        self::assertEquals($entities, $result['entities']);
+        self::assertEquals('getList', $this->routeMatch->getParam('action'));
     }
 
     public function testDispatchInvokesGetMethodWhenNoActionPresentAndIdentifierPresentOnGet(): void
@@ -82,9 +82,9 @@ class RestfulControllerTest extends TestCase
         $this->controller->entity = $entity;
         $this->routeMatch->setParam('id', 1);
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertArrayHasKey('entity', $result);
-        $this->assertEquals($entity, $result['entity']);
-        $this->assertEquals('get', $this->routeMatch->getParam('action'));
+        self::assertArrayHasKey('entity', $result);
+        self::assertEquals($entity, $result['entity']);
+        self::assertEquals('get', $this->routeMatch->getParam('action'));
     }
 
     public function testDispatchInvokesCreateMethodWhenNoActionPresentAndPostInvoked(): void
@@ -94,9 +94,9 @@ class RestfulControllerTest extends TestCase
         $post = $this->request->getPost();
         $post->fromArray($entity);
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertArrayHasKey('entity', $result);
-        $this->assertEquals($entity, $result['entity']);
-        $this->assertEquals('create', $this->routeMatch->getParam('action'));
+        self::assertArrayHasKey('entity', $result);
+        self::assertEquals($entity, $result['entity']);
+        self::assertEquals('create', $this->routeMatch->getParam('action'));
     }
 
     public function testCanReceiveStringAsRequestContent(): void
@@ -110,9 +110,9 @@ class RestfulControllerTest extends TestCase
         $controller->setEvent($this->event);
         $result = $controller->dispatch($this->request, $this->response);
 
-        $this->assertEquals($id, $result['id']);
-        $this->assertEquals($string, $result['data']);
-        $this->assertEquals('update', $this->routeMatch->getParam('action'));
+        self::assertEquals($id, $result['id']);
+        self::assertEquals($string, $result['data']);
+        self::assertEquals('update', $this->routeMatch->getParam('action'));
     }
 
     public function testDispatchInvokesUpdateMethodWhenNoActionPresentAndPutInvokedWithIdentifier(): void
@@ -123,13 +123,13 @@ class RestfulControllerTest extends TestCase
                       ->setContent($string);
         $this->routeMatch->setParam('id', 1);
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertArrayHasKey('entity', $result);
+        self::assertArrayHasKey('entity', $result);
         $test = $result['entity'];
-        $this->assertArrayHasKey('id', $test);
-        $this->assertEquals(1, $test['id']);
-        $this->assertArrayHasKey('name', $test);
-        $this->assertEquals(__FUNCTION__, $test['name']);
-        $this->assertEquals('update', $this->routeMatch->getParam('action'));
+        self::assertArrayHasKey('id', $test);
+        self::assertEquals(1, $test['id']);
+        self::assertArrayHasKey('name', $test);
+        self::assertEquals(__FUNCTION__, $test['name']);
+        self::assertEquals('update', $this->routeMatch->getParam('action'));
     }
 
     public function testDispatchInvokesReplaceListMethodWhenNoActionPresentAndPutInvokedWithoutIdentifier(): void
@@ -143,8 +143,8 @@ class RestfulControllerTest extends TestCase
         $this->request->setMethod('PUT')
                       ->setContent($string);
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertEquals($entities, $result);
-        $this->assertEquals('replaceList', $this->routeMatch->getParam('action'));
+        self::assertEquals($entities, $result);
+        self::assertEquals('replaceList', $this->routeMatch->getParam('action'));
     }
 
     public function testDispatchInvokesPatchListMethodWhenNoActionPresentAndPatchInvokedWithoutIdentifier(): void
@@ -158,8 +158,8 @@ class RestfulControllerTest extends TestCase
         $this->request->setMethod('PATCH')
                       ->setContent($string);
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertEquals($entities, $result);
-        $this->assertEquals('patchList', $this->routeMatch->getParam('action'));
+        self::assertEquals($entities, $result);
+        self::assertEquals('patchList', $this->routeMatch->getParam('action'));
     }
 
     public function testDispatchInvokesDeleteMethodWhenNoActionPresentAndDeleteInvokedWithIdentifier(): void
@@ -169,9 +169,9 @@ class RestfulControllerTest extends TestCase
         $this->request->setMethod('DELETE');
         $this->routeMatch->setParam('id', 1);
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertEquals([], $result);
-        $this->assertEquals([], $this->controller->entity);
-        $this->assertEquals('delete', $this->routeMatch->getParam('action'));
+        self::assertEquals([], $result);
+        self::assertEquals([], $this->controller->entity);
+        self::assertEquals('delete', $this->routeMatch->getParam('action'));
     }
 
     public function testDispatchInvokesDeleteListMethodWhenNoActionPresentAndDeleteInvokedWithoutIdentifier(): void
@@ -188,26 +188,26 @@ class RestfulControllerTest extends TestCase
         $this->request->setMethod('DELETE')
                       ->setContent($string);
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertEmpty($this->controller->entity);
-        $this->assertEquals(204, $result->getStatusCode());
-        $this->assertTrue($result->getHeaders()->has('X-Deleted'));
-        $this->assertEquals('deleteList', $this->routeMatch->getParam('action'));
+        self::assertEmpty($this->controller->entity);
+        self::assertEquals(204, $result->getStatusCode());
+        self::assertTrue($result->getHeaders()->has('X-Deleted'));
+        self::assertEquals('deleteList', $this->routeMatch->getParam('action'));
     }
 
     public function testDispatchInvokesOptionsMethodWhenNoActionPresentAndOptionsInvoked(): void
     {
         $this->request->setMethod('OPTIONS');
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertSame($this->response, $result);
-        $this->assertEquals('options', $this->routeMatch->getParam('action'));
+        self::assertSame($this->response, $result);
+        self::assertEquals('options', $this->routeMatch->getParam('action'));
         $headers = $result->getHeaders();
-        $this->assertTrue($headers->has('Allow'));
+        self::assertTrue($headers->has('Allow'));
         $allow    = $headers->get('Allow');
         $expected = explode(', ', 'GET, POST, PUT, DELETE, PATCH, HEAD, TRACE');
         sort($expected);
         $test = explode(', ', $allow->getFieldValue());
         sort($test);
-        $this->assertEquals($expected, $test);
+        self::assertEquals($expected, $test);
     }
 
     public function testDispatchInvokesPatchMethodWhenNoActionPresentAndPatchInvokedWithIdentifier(): void
@@ -222,15 +222,15 @@ class RestfulControllerTest extends TestCase
                       ->setContent($string);
         $this->routeMatch->setParam('id', 1);
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertArrayHasKey('entity', $result);
+        self::assertArrayHasKey('entity', $result);
         $test = $result['entity'];
-        $this->assertArrayHasKey('id', $test);
-        $this->assertEquals(1, $test['id']);
-        $this->assertArrayHasKey('name', $test);
-        $this->assertEquals(__FUNCTION__, $test['name']);
-        $this->assertArrayHasKey('type', $test);
-        $this->assertEquals('standard', $test['type']);
-        $this->assertEquals('patch', $this->routeMatch->getParam('action'));
+        self::assertArrayHasKey('id', $test);
+        self::assertEquals(1, $test['id']);
+        self::assertArrayHasKey('name', $test);
+        self::assertEquals(__FUNCTION__, $test['name']);
+        self::assertArrayHasKey('type', $test);
+        self::assertEquals('standard', $test['type']);
+        self::assertEquals('patch', $this->routeMatch->getParam('action'));
     }
 
     /**
@@ -245,10 +245,10 @@ class RestfulControllerTest extends TestCase
         $this->request->setMethod('HEAD');
         $result = $this->controller->dispatch($this->request, $this->response);
 
-        $this->assertEquals(418, $result->getStatusCode());
-        $this->assertEquals('', $result->getContent());
-        $this->assertEquals('head', $this->routeMatch->getParam('action'));
-        $this->assertEquals('Header Value', $result->getHeaders()->get('Custom-Header')->getFieldValue());
+        self::assertEquals(418, $result->getStatusCode());
+        self::assertEquals('', $result->getContent());
+        self::assertEquals('head', $this->routeMatch->getParam('action'));
+        self::assertEquals('Header Value', $result->getHeaders()->get('Custom-Header')->getFieldValue());
     }
 
     public function testDispatchInvokesHeadMethodWhenNoActionPresentAndHeadInvokedWithoutIdentifier(): void
@@ -261,10 +261,10 @@ class RestfulControllerTest extends TestCase
         $this->controller->entities = $entities;
         $this->request->setMethod('HEAD');
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertSame($this->response, $result);
+        self::assertSame($this->response, $result);
         $content = $result->getContent();
-        $this->assertEquals('', $content);
-        $this->assertEquals('head', $this->routeMatch->getParam('action'));
+        self::assertEquals('', $content);
+        self::assertEquals('head', $this->routeMatch->getParam('action'));
     }
 
     public function testDispatchInvokesHeadMethodWhenNoActionPresentAndHeadInvokedWithIdentifier(): void
@@ -274,15 +274,15 @@ class RestfulControllerTest extends TestCase
         $this->routeMatch->setParam('id', 1);
         $this->request->setMethod('HEAD');
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertSame($this->response, $result);
+        self::assertSame($this->response, $result);
         $content = $result->getContent();
-        $this->assertEquals('', $content);
-        $this->assertEquals('head', $this->routeMatch->getParam('action'));
+        self::assertEquals('', $content);
+        self::assertEquals('head', $this->routeMatch->getParam('action'));
 
         $headers = $this->controller->getResponse()->getHeaders();
-        $this->assertTrue($headers->has('X-Laminas-Id'));
+        self::assertTrue($headers->has('X-Laminas-Id'));
         $header = $headers->get('X-Laminas-Id');
-        $this->assertEquals(1, $header->getFieldValue());
+        self::assertEquals(1, $header->getFieldValue());
     }
 
     public function testAllowsRegisteringCustomHttpMethodsWithHandlers(): void
@@ -290,16 +290,16 @@ class RestfulControllerTest extends TestCase
         $this->controller->addHttpMethodHandler('DESCRIBE', [$this->controller, 'describe']);
         $this->request->setMethod('DESCRIBE');
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertArrayHasKey('description', $result);
-        $this->assertStringContainsString('::describe', $result['description']);
+        self::assertArrayHasKey('description', $result);
+        self::assertStringContainsString('::describe', $result['description']);
     }
 
     public function testDispatchCallsActionMethodBasedOnNormalizingAction(): void
     {
         $this->routeMatch->setParam('action', 'test.some-strangely_separated.words');
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertArrayHasKey('content', $result);
-        $this->assertStringContainsString('Test Some Strangely Separated Words', $result['content']);
+        self::assertArrayHasKey('content', $result);
+        self::assertStringContainsString('Test Some Strangely Separated Words', $result['content']);
     }
 
     public function testDispatchCallsNotFoundActionWhenActionPassedThatCannotBeMatched(): void
@@ -307,9 +307,9 @@ class RestfulControllerTest extends TestCase
         $this->routeMatch->setParam('action', 'test-some-made-up-action');
         $result   = $this->controller->dispatch($this->request, $this->response);
         $response = $this->controller->getResponse();
-        $this->assertEquals(404, $response->getStatusCode());
-        $this->assertArrayHasKey('content', $result);
-        $this->assertStringContainsString('Page not found', $result['content']);
+        self::assertEquals(404, $response->getStatusCode());
+        self::assertArrayHasKey('content', $result);
+        self::assertStringContainsString('Page not found', $result['content']);
     }
 
     public function testShortCircuitsBeforeActionIfPreDispatchReturnsAResponse(): void
@@ -322,7 +322,7 @@ class RestfulControllerTest extends TestCase
             10
         );
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertSame($response, $result);
+        self::assertSame($response, $result);
     }
 
     public function testPostDispatchEventAllowsReplacingResponse(): void
@@ -335,7 +335,7 @@ class RestfulControllerTest extends TestCase
             -10
         );
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertSame($response, $result);
+        self::assertSame($response, $result);
     }
 
     public function testEventManagerListensOnDispatchableInterfaceByDefault(): void
@@ -349,7 +349,7 @@ class RestfulControllerTest extends TestCase
             10
         );
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertSame($response, $result);
+        self::assertSame($response, $result);
     }
 
     public function testEventManagerListensOnRestfulControllerClassByDefault(): void
@@ -363,7 +363,7 @@ class RestfulControllerTest extends TestCase
             10
         );
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertSame($response, $result);
+        self::assertSame($response, $result);
     }
 
     public function testEventManagerListensOnClassNameByDefault(): void
@@ -377,38 +377,38 @@ class RestfulControllerTest extends TestCase
             10
         );
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertSame($response, $result);
+        self::assertSame($response, $result);
     }
 
     public function testDispatchInjectsEventIntoController(): void
     {
         $this->controller->dispatch($this->request, $this->response);
         $event = $this->controller->getEvent();
-        $this->assertNotNull($event);
-        $this->assertSame($this->event, $event);
+        self::assertNotNull($event);
+        self::assertSame($this->event, $event);
     }
 
     public function testControllerIsEventAware(): void
     {
-        $this->assertInstanceOf(InjectApplicationEventInterface::class, $this->controller);
+        self::assertInstanceOf(InjectApplicationEventInterface::class, $this->controller);
     }
 
     public function testControllerIsPluggable(): void
     {
-        $this->assertTrue(method_exists($this->controller, 'plugin'));
+        self::assertTrue(method_exists($this->controller, 'plugin'));
     }
 
     public function testMethodOverloadingShouldReturnPluginWhenFound(): void
     {
         $plugin = $this->controller->url();
-        $this->assertInstanceOf(Url::class, $plugin);
+        self::assertInstanceOf(Url::class, $plugin);
     }
 
     public function testMethodOverloadingShouldInvokePluginAsFunctorIfPossible(): void
     {
         $model = $this->event->getViewModel();
         $this->controller->layout('alternate/layout');
-        $this->assertEquals('alternate/layout', $model->getTemplate());
+        self::assertEquals('alternate/layout', $model->getTemplate());
     }
 
     public function testParsingDataAsJsonWillReturnAsArray(): void
@@ -418,8 +418,8 @@ class RestfulControllerTest extends TestCase
         $this->request->setContent('{"foo":"bar"}');
 
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertIsArray($result);
-        $this->assertEquals(['entity' => ['foo' => 'bar']], $result);
+        self::assertIsArray($result);
+        self::assertEquals(['entity' => ['foo' => 'bar']], $result);
     }
 
     public static function matchingContentTypes(): array
@@ -438,7 +438,7 @@ class RestfulControllerTest extends TestCase
     public function testRequestingContentTypeReturnsTrueForValidMatches(string $contentType): void
     {
         $this->request->getHeaders()->addHeaderLine('Content-Type', $contentType);
-        $this->assertTrue($this->controller->requestHasContentType(
+        self::assertTrue($this->controller->requestHasContentType(
             $this->request,
             RestfulTestController::CONTENT_TYPE_JSON
         ));
@@ -458,7 +458,7 @@ class RestfulControllerTest extends TestCase
     public function testRequestingContentTypeReturnsFalseForInvalidMatches(string $contentType): void
     {
         $this->request->getHeaders()->addHeaderLine('Content-Type', $contentType);
-        $this->assertFalse($this->controller->requestHasContentType(
+        self::assertFalse($this->controller->requestHasContentType(
             $this->request,
             RestfulTestController::CONTENT_TYPE_JSON
         ));
@@ -468,8 +468,8 @@ class RestfulControllerTest extends TestCase
     {
         $this->request->setMethod('PROPFIND');
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertInstanceOf(Response::class, $result);
-        $this->assertEquals(405, $result->getStatusCode());
+        self::assertInstanceOf(Response::class, $result);
+        self::assertEquals(405, $result->getStatusCode());
     }
 
     public function testDispatchInvokesGetMethodWhenNoActionPresentAndZeroIdentifierPresentOnGet(): void
@@ -478,20 +478,20 @@ class RestfulControllerTest extends TestCase
         $this->controller->entity = $entity;
         $this->routeMatch->setParam('id', 0);
         $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertArrayHasKey('entity', $result);
-        $this->assertEquals($entity, $result['entity']);
-        $this->assertEquals('get', $this->routeMatch->getParam('action'));
+        self::assertArrayHasKey('entity', $result);
+        self::assertEquals($entity, $result['entity']);
+        self::assertEquals('get', $this->routeMatch->getParam('action'));
     }
 
     public function testIdentifierNameDefaultsToId(): void
     {
-        $this->assertEquals('id', $this->controller->getIdentifierName());
+        self::assertEquals('id', $this->controller->getIdentifierName());
     }
 
     public function testCanSetIdentifierName(): void
     {
         $this->controller->setIdentifierName('name');
-        $this->assertEquals('name', $this->controller->getIdentifierName());
+        self::assertEquals('name', $this->controller->getIdentifierName());
     }
 
     public function testUsesConfiguredIdentifierNameToGetIdentifier(): void
@@ -504,12 +504,12 @@ class RestfulControllerTest extends TestCase
 
         $this->routeMatch->setParam('name', 'foo');
         $result = $getIdentifier->invoke($this->controller, $this->routeMatch, $this->request);
-        $this->assertEquals('foo', $result);
+        self::assertEquals('foo', $result);
 
         $this->routeMatch->setParam('name', false);
         $this->request->getQuery()->set('name', 'bar');
         $result = $getIdentifier->invoke($this->controller, $this->routeMatch, $this->request);
-        $this->assertEquals('bar', $result);
+        self::assertEquals('bar', $result);
     }
 
     /**
@@ -533,8 +533,8 @@ class RestfulControllerTest extends TestCase
         $result   = $this->emptyController->dispatch($this->request, $this->response);
         $response = $this->emptyController->getResponse();
 
-        $this->assertEquals(405, $response->getStatusCode());
-        $this->assertEquals('Method Not Allowed', $this->response->getReasonPhrase());
+        self::assertEquals(405, $response->getStatusCode());
+        self::assertEquals('Method Not Allowed', $this->response->getReasonPhrase());
     }
 
     public static function providerNotImplementedMethodSets504HttpCodeProvider(): array

--- a/test/DispatchListenerTest.php
+++ b/test/DispatchListenerTest.php
@@ -66,9 +66,9 @@ class DispatchListenerTest extends TestCase
 
         $return = $listener->onDispatch($event);
 
-        $this->assertEmpty($log, var_export($log, true));
-        $this->assertSame($event->getResponse(), $return);
-        $this->assertSame(200, $return->getStatusCode());
+        self::assertEmpty($log, var_export($log, true));
+        self::assertSame($event->getResponse(), $return);
+        self::assertSame(200, $return->getStatusCode());
     }
 
     public function testUnlocatableControllerViaAbstractFactory(): void
@@ -92,8 +92,8 @@ class DispatchListenerTest extends TestCase
 
         $return = $listener->onDispatch($event);
 
-        $this->assertArrayHasKey('error', $log);
-        $this->assertSame('error-controller-not-found', $log['error']);
+        self::assertArrayHasKey('error', $log);
+        self::assertSame('error-controller-not-found', $log['error']);
     }
 
     /**

--- a/test/Exception/InvalidMiddlewareExceptionTest.php
+++ b/test/Exception/InvalidMiddlewareExceptionTest.php
@@ -16,23 +16,23 @@ final class InvalidMiddlewareExceptionTest extends TestCase
         $middlewareName = uniqid('middlewareName', true);
         $exception      = InvalidMiddlewareException::fromMiddlewareName($middlewareName);
 
-        $this->assertInstanceOf(InvalidMiddlewareException::class, $exception);
-        $this->assertSame('Cannot dispatch middleware ' . $middlewareName, $exception->getMessage());
-        $this->assertSame($middlewareName, $exception->toMiddlewareName());
+        self::assertInstanceOf(InvalidMiddlewareException::class, $exception);
+        self::assertSame('Cannot dispatch middleware ' . $middlewareName, $exception->getMessage());
+        self::assertSame($middlewareName, $exception->toMiddlewareName());
     }
 
     public function testToMiddlewareNameWhenNotSet()
     {
         $exception = new InvalidMiddlewareException();
-        $this->assertSame('', $exception->toMiddlewareName());
+        self::assertSame('', $exception->toMiddlewareName());
     }
 
     public function testFromNull()
     {
         $exception = InvalidMiddlewareException::fromNull();
 
-        $this->assertInstanceOf(InvalidMiddlewareException::class, $exception);
-        $this->assertSame('Middleware name cannot be null', $exception->getMessage());
-        $this->assertSame('', $exception->toMiddlewareName());
+        self::assertInstanceOf(InvalidMiddlewareException::class, $exception);
+        self::assertSame('Middleware name cannot be null', $exception->getMessage());
+        self::assertSame('', $exception->toMiddlewareName());
     }
 }

--- a/test/Exception/ReachedFinalHandlerExceptionTest.php
+++ b/test/Exception/ReachedFinalHandlerExceptionTest.php
@@ -13,8 +13,8 @@ final class ReachedFinalHandlerExceptionTest extends TestCase
     {
         $exception = ReachedFinalHandlerException::create();
 
-        $this->assertInstanceOf(ReachedFinalHandlerException::class, $exception);
-        $this->assertSame(
+        self::assertInstanceOf(ReachedFinalHandlerException::class, $exception);
+        self::assertSame(
             'Reached the final handler for middleware pipe - check the pipe configuration',
             $exception->getMessage()
         );

--- a/test/HttpMethodListenerTest.php
+++ b/test/HttpMethodListenerTest.php
@@ -30,11 +30,11 @@ class HttpMethodListenerTest extends TestCase
         $methods  = ['foo', 'bar'];
         $listener = new HttpMethodListener(false, $methods);
 
-        $this->assertFalse($listener->isEnabled());
-        $this->assertSame(['FOO', 'BAR'], $listener->getAllowedMethods());
+        self::assertFalse($listener->isEnabled());
+        self::assertSame(['FOO', 'BAR'], $listener->getAllowedMethods());
 
         $listener = new HttpMethodListener(true, []);
-        $this->assertNotEmpty($listener->getAllowedMethods());
+        self::assertNotEmpty($listener->getAllowedMethods());
     }
 
     public function testAttachesToRouteEvent(): void
@@ -63,12 +63,12 @@ class HttpMethodListenerTest extends TestCase
         $event = new MvcEvent();
         $event->setRequest(new Request());
 
-        $this->assertNull($this->listener->onRoute($event));
+        self::assertNull($this->listener->onRoute($event));
 
         $event->setRequest(new HttpRequest());
         $event->setResponse(new Response());
 
-        $this->assertNull($this->listener->onRoute($event));
+        self::assertNull($this->listener->onRoute($event));
     }
 
     public function testOnRouteDoesNothingIfIfMethodIsAllowed(): void
@@ -81,7 +81,7 @@ class HttpMethodListenerTest extends TestCase
 
         $this->listener->setAllowedMethods(['foo']);
 
-        $this->assertNull($this->listener->onRoute($event));
+        self::assertNull($this->listener->onRoute($event));
     }
 
     public function testOnRouteReturns405ResponseIfMethodNotAllowed(): void
@@ -94,7 +94,7 @@ class HttpMethodListenerTest extends TestCase
 
         $response = $this->listener->onRoute($event);
 
-        $this->assertInstanceOf(HttpResponse::class, $response);
-        $this->assertSame(405, $response->getStatusCode());
+        self::assertInstanceOf(HttpResponse::class, $response);
+        self::assertSame(405, $response->getStatusCode());
     }
 }

--- a/test/ModuleRouteListenerTest.php
+++ b/test/ModuleRouteListenerTest.php
@@ -53,9 +53,9 @@ class ModuleRouteListenerTest extends TestCase
         $this->events->triggerEvent($event);
 
         $matches = $event->getRouteMatch();
-        $this->assertInstanceOf(RouteMatch::class, $matches);
-        $this->assertEquals('Foo\Index', $matches->getParam('controller'));
-        $this->assertEquals('Index', $matches->getParam(ModuleRouteListener::ORIGINAL_CONTROLLER));
+        self::assertInstanceOf(RouteMatch::class, $matches);
+        self::assertEquals('Foo\Index', $matches->getParam('controller'));
+        self::assertEquals('Index', $matches->getParam(ModuleRouteListener::ORIGINAL_CONTROLLER));
     }
 
     public function testRouteNotReturningModuleNamespaceInRouteMatchLeavesControllerUntouched(): void
@@ -77,8 +77,8 @@ class ModuleRouteListenerTest extends TestCase
         $this->events->triggerEvent($event);
 
         $matches = $event->getRouteMatch();
-        $this->assertInstanceOf(RouteMatch::class, $matches);
-        $this->assertEquals('Index', $matches->getParam('controller'));
+        self::assertInstanceOf(RouteMatch::class, $matches);
+        self::assertEquals('Index', $matches->getParam('controller'));
     }
 
     public function testMultipleRegistrationShouldNotResultInMultiplePrefixingOfControllerName(): void
@@ -104,9 +104,9 @@ class ModuleRouteListenerTest extends TestCase
         $this->events->triggerEvent($event);
 
         $matches = $event->getRouteMatch();
-        $this->assertInstanceOf(RouteMatch::class, $matches);
-        $this->assertEquals('Foo\Index', $matches->getParam('controller'));
-        $this->assertEquals('Index', $matches->getParam(ModuleRouteListener::ORIGINAL_CONTROLLER));
+        self::assertInstanceOf(RouteMatch::class, $matches);
+        self::assertEquals('Foo\Index', $matches->getParam('controller'));
+        self::assertEquals('Index', $matches->getParam(ModuleRouteListener::ORIGINAL_CONTROLLER));
     }
 
     public function testRouteMatchIsTransformedToProperControllerClassName(): void
@@ -133,8 +133,8 @@ class ModuleRouteListenerTest extends TestCase
         $this->events->triggerEvent($event);
 
         $matches = $event->getRouteMatch();
-        $this->assertInstanceOf(RouteMatch::class, $matches);
-        $this->assertEquals('Foo\SomeIndex', $matches->getParam('controller'));
-        $this->assertEquals('some-index', $matches->getParam(ModuleRouteListener::ORIGINAL_CONTROLLER));
+        self::assertInstanceOf(RouteMatch::class, $matches);
+        self::assertEquals('Foo\SomeIndex', $matches->getParam('controller'));
+        self::assertEquals('some-index', $matches->getParam(ModuleRouteListener::ORIGINAL_CONTROLLER));
     }
 }

--- a/test/ResponseSender/AbstractResponseSenderTest.php
+++ b/test/ResponseSender/AbstractResponseSenderTest.php
@@ -52,8 +52,8 @@ class AbstractResponseSenderTest extends TestCase
 
         if (count($diff)) {
             $header = array_shift($diff);
-            $this->assertContains('XDEBUG_SESSION', $header);
-            $this->assertEquals(0, count($diff));
+            self::assertContains('XDEBUG_SESSION', $header);
+            self::assertEquals(0, count($diff));
         }
 
         $expected = [];
@@ -62,7 +62,7 @@ class AbstractResponseSenderTest extends TestCase
         }
 
         $responseSender->sendHeaders($mockSendResponseEvent);
-        $this->assertEquals($expected, xdebug_get_headers());
+        self::assertEquals($expected, xdebug_get_headers());
     }
 
     /**
@@ -94,9 +94,9 @@ class AbstractResponseSenderTest extends TestCase
 
         $sentHeaders = xdebug_get_headers();
 
-        $this->assertCount(2, $sentHeaders);
-        $this->assertEquals('Location: example.com', $sentHeaders[0]);
-        $this->assertEquals(
+        self::assertCount(2, $sentHeaders);
+        self::assertEquals('Location: example.com', $sentHeaders[0]);
+        self::assertEquals(
             'X-Test: HTTP/1.1 202 Accepted',
             $sentHeaders[1],
             'Status header is sent last to prevent header() from overwriting the Laminas status code when a Location '

--- a/test/ResponseSender/PhpEnvironmentResponseSenderTest.php
+++ b/test/ResponseSender/PhpEnvironmentResponseSenderTest.php
@@ -24,7 +24,7 @@ class PhpEnvironmentResponseSenderTest extends TestCase
         ob_start();
         $responseSender($mockSendResponseEvent);
         $body = ob_get_clean();
-        $this->assertEquals('', $body);
+        self::assertEquals('', $body);
     }
 
     public function testSendResponseTwoTimesPrintsResponseOnlyOnce()
@@ -38,12 +38,12 @@ class PhpEnvironmentResponseSenderTest extends TestCase
         ob_start();
         $responseSender($mockSendResponseEvent);
         $body = ob_get_clean();
-        $this->assertEquals('body', $body);
+        self::assertEquals('body', $body);
 
         ob_start();
         $responseSender($mockSendResponseEvent);
         $body = ob_get_clean();
-        $this->assertEquals('', $body);
+        self::assertEquals('', $body);
     }
 
     protected function getSendResponseEventMock(): SendResponseEvent

--- a/test/ResponseSender/SendResponseEventTest.php
+++ b/test/ResponseSender/SendResponseEventTest.php
@@ -16,14 +16,14 @@ class SendResponseEventTest extends TestCase
         $mockResponse2 = $this->getMockForAbstractClass(ResponseInterface::class);
         $event         = new SendResponseEvent();
         $event->setResponse($mockResponse);
-        $this->assertFalse($event->headersSent());
-        $this->assertFalse($event->contentSent());
+        self::assertFalse($event->headersSent());
+        self::assertFalse($event->contentSent());
         $event->setHeadersSent();
         $event->setContentSent();
-        $this->assertTrue($event->headersSent());
-        $this->assertTrue($event->contentSent());
+        self::assertTrue($event->headersSent());
+        self::assertTrue($event->contentSent());
         $event->setResponse($mockResponse2);
-        $this->assertFalse($event->headersSent());
-        $this->assertFalse($event->contentSent());
+        self::assertFalse($event->headersSent());
+        self::assertFalse($event->contentSent());
     }
 }

--- a/test/ResponseSender/SimpleStreamResponseSenderTest.php
+++ b/test/ResponseSender/SimpleStreamResponseSenderTest.php
@@ -25,7 +25,7 @@ class SimpleStreamResponseSenderTest extends TestCase
         ob_start();
         $responseSender($mockSendResponseEvent);
         $body = ob_get_clean();
-        $this->assertEquals('', $body);
+        self::assertEquals('', $body);
     }
 
     public function testSendResponseTwoTimesPrintsResponseOnlyOnce(): void
@@ -39,12 +39,12 @@ class SimpleStreamResponseSenderTest extends TestCase
         $responseSender($mockSendResponseEvent);
         $body     = ob_get_clean();
         $expected = file_get_contents(__DIR__ . '/TestAsset/sample-stream-file.txt');
-        $this->assertEquals($expected, $body);
+        self::assertEquals($expected, $body);
 
         ob_start();
         $responseSender($mockSendResponseEvent);
         $body = ob_get_clean();
-        $this->assertEquals('', $body);
+        self::assertEquals('', $body);
     }
 
     protected function getSendResponseEventMock(ResponseInterface $response): SendResponseEvent

--- a/test/SendResponseListenerTest.php
+++ b/test/SendResponseListenerTest.php
@@ -19,7 +19,7 @@ class SendResponseListenerTest extends TestCase
         $listener    = new SendResponseListener();
         $identifiers = $listener->getEventManager()->getIdentifiers();
         $expected    = [SendResponseListener::class];
-        $this->assertEquals($expected, array_values($identifiers));
+        self::assertEquals($expected, array_values($identifiers));
     }
 
     public function testSendResponseTriggersSendResponseEvent(): void
@@ -44,6 +44,6 @@ class SendResponseListenerTest extends TestCase
             'target'   => $listener,
             'response' => $mockResponse,
         ];
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 }

--- a/test/Service/ControllerManagerFactoryTest.php
+++ b/test/Service/ControllerManagerFactoryTest.php
@@ -58,7 +58,7 @@ class ControllerManagerFactoryTest extends TestCase
         $loader = $this->services->get('ControllerManager');
 
         // Ensure the class exists and can be autoloaded
-        $this->assertTrue(class_exists(InvalidDispatchableClass::class));
+        self::assertTrue(class_exists(InvalidDispatchableClass::class));
 
         $loader->setFactory(InvalidDispatchableClass::class, InvokableFactory::class);
 
@@ -67,7 +67,7 @@ class ControllerManagerFactoryTest extends TestCase
             $this->fail('Retrieving the invalid dispatchable should fail');
         } catch (Exception $e) {
             do {
-                $this->assertStringContainsString('Should not instantiate this', $e->getMessage());
+                self::assertStringContainsString('Should not instantiate this', $e->getMessage());
             } while ($e = $e->getPrevious());
         }
     }
@@ -93,9 +93,9 @@ class ControllerManagerFactoryTest extends TestCase
         $loader->setFactory(Dispatchable::class, InvokableFactory::class);
 
         $controller = $loader->get('LaminasTest\Dispatchable');
-        $this->assertInstanceOf(Dispatchable::class, $controller);
-        $this->assertSame($this->services->get('EventManager'), $controller->getEventManager());
-        $this->assertSame($this->services->get('ControllerPluginManager'), $controller->getPluginManager());
+        self::assertInstanceOf(Dispatchable::class, $controller);
+        self::assertSame($this->services->get('EventManager'), $controller->getEventManager());
+        self::assertSame($this->services->get('ControllerPluginManager'), $controller->getPluginManager());
     }
 
     public function testCallPluginWithControllerPluginManager()
@@ -108,6 +108,6 @@ class ControllerManagerFactoryTest extends TestCase
         $controllerPluginManager->setController($controller);
 
         $plugin = $controllerPluginManager->get('samplePlugin');
-        $this->assertEquals($controller, $plugin->getController());
+        self::assertEquals($controller, $plugin->getController());
     }
 }

--- a/test/Service/HttpMethodListenerFactoryTest.php
+++ b/test/Service/HttpMethodListenerFactoryTest.php
@@ -18,8 +18,8 @@ class HttpMethodListenerFactoryTest extends TestCase
         $serviceLocator = $this->createMock(ServiceLocatorInterface::class);
         $factory        = new HttpMethodListenerFactory();
         $listener       = $factory($serviceLocator, 'HttpMethodListener');
-        $this->assertTrue($listener->isEnabled());
-        $this->assertNotEmpty($listener->getAllowedMethods());
+        self::assertTrue($listener->isEnabled());
+        self::assertNotEmpty($listener->getAllowedMethods());
     }
 
     public function testCreateWithConfig()
@@ -39,7 +39,7 @@ class HttpMethodListenerFactoryTest extends TestCase
 
         $listenerConfig = $config['http_methods_listener'];
 
-        $this->assertSame($listenerConfig['enabled'], $listener->isEnabled());
-        $this->assertSame($listenerConfig['allowed_methods'], $listener->getAllowedMethods());
+        self::assertSame($listenerConfig['enabled'], $listener->isEnabled());
+        self::assertSame($listenerConfig['allowed_methods'], $listener->getAllowedMethods());
     }
 }

--- a/test/Service/InjectTemplateListenerFactoryTest.php
+++ b/test/Service/InjectTemplateListenerFactoryTest.php
@@ -33,7 +33,7 @@ class InjectTemplateListenerFactoryTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals('some/module', $listener->mapController("SomeModule"));
+        self::assertEquals('some/module', $listener->mapController("SomeModule"));
     }
 
     public function testFactoryCanSetControllerMapViaArrayAccessVM()
@@ -47,7 +47,7 @@ class InjectTemplateListenerFactoryTest extends TestCase
             ]),
         ]);
 
-        $this->assertEquals('some/module', $listener->mapController("SomeModule"));
+        self::assertEquals('some/module', $listener->mapController("SomeModule"));
     }
 
     /**
@@ -61,7 +61,7 @@ class InjectTemplateListenerFactoryTest extends TestCase
         $factory  = new InjectTemplateListenerFactory();
         $listener = $factory($serviceLocator, 'InjectTemplateListener');
 
-        $this->assertInstanceOf(InjectTemplateListener::class, $listener);
+        self::assertInstanceOf(InjectTemplateListener::class, $listener);
 
         return $listener;
     }

--- a/test/Service/RequestFactoryTest.php
+++ b/test/Service/RequestFactoryTest.php
@@ -17,6 +17,6 @@ class RequestFactoryTest extends TestCase
         $factory   = new RequestFactory();
         $container = $this->createMock(ContainerInterface::class);
         $request   = $factory($container, 'Request');
-        $this->assertInstanceOf(HttpRequest::class, $request);
+        self::assertInstanceOf(HttpRequest::class, $request);
     }
 }

--- a/test/Service/ResponseFactoryTest.php
+++ b/test/Service/ResponseFactoryTest.php
@@ -17,6 +17,6 @@ class ResponseFactoryTest extends TestCase
         $container = $this->createMock(ContainerInterface::class);
         $factory   = new ResponseFactory();
         $response  = $factory($container, 'Response');
-        $this->assertInstanceOf(HttpResponse::class, $response);
+        self::assertInstanceOf(HttpResponse::class, $response);
     }
 }

--- a/test/Service/SendResponseListenerFactoryTest.php
+++ b/test/Service/SendResponseListenerFactoryTest.php
@@ -62,7 +62,7 @@ class SendResponseListenerFactoryTest extends TestCase
 
         $factory  = new SendResponseListenerFactory();
         $listener = $factory($container);
-        $this->assertInstanceOf(SendResponseListener::class, $listener);
-        $this->assertSame($events, $listener->getEventManager());
+        self::assertInstanceOf(SendResponseListener::class, $listener);
+        self::assertSame($events, $listener->getEventManager());
     }
 }

--- a/test/Service/ServiceManagerConfigTest.php
+++ b/test/Service/ServiceManagerConfigTest.php
@@ -48,9 +48,9 @@ class ServiceManagerConfigTest extends TestCase
         $this->services->setFactory(EventManagerAwareObject::class, InvokableFactory::class);
 
         $instance = $this->services->get('EventManagerAwareObject');
-        $this->assertInstanceOf(EventManagerAwareObject::class, $instance);
-        $this->assertSame($events, $instance->getEventManager());
-        $this->assertSame($this->services->get('SharedEventManager'), $events->getSharedManager());
+        self::assertInstanceOf(EventManagerAwareObject::class, $instance);
+        self::assertSame($events, $instance->getEventManager());
+        self::assertSame($this->services->get('SharedEventManager'), $events->getSharedManager());
     }
 
     public function testCanMergeCustomConfigWithDefaultConfig(): void
@@ -67,9 +67,9 @@ class ServiceManagerConfigTest extends TestCase
         $sm = new ServiceManager();
         (new ServiceManagerConfig($custom))->configureServiceManager($sm);
 
-        $this->assertTrue($sm->has('foo'));
-        $this->assertTrue($sm->has('bar'));
-        $this->assertTrue($sm->has('ModuleManager'));
+        self::assertTrue($sm->has('foo'));
+        self::assertTrue($sm->has('bar'));
+        self::assertTrue($sm->has('ModuleManager'));
     }
 
     public function testCanOverrideDefaultConfigWithCustomConfig(): void
@@ -86,10 +86,10 @@ class ServiceManagerConfigTest extends TestCase
         $sm = new ServiceManager();
         (new ServiceManagerConfig($custom))->configureServiceManager($sm);
 
-        $this->assertTrue($sm->has('foo'));
-        $this->assertTrue($sm->has('ModuleManager'));
+        self::assertTrue($sm->has('foo'));
+        self::assertTrue($sm->has('ModuleManager'));
 
-        $this->assertInstanceOf(stdClass::class, $sm->get('ModuleManager'));
+        self::assertInstanceOf(stdClass::class, $sm->get('ModuleManager'));
     }
 
     public function testCanAddDelegators(): void
@@ -119,8 +119,8 @@ class ServiceManagerConfigTest extends TestCase
         (new ServiceManagerConfig($config))->configureServiceManager($sm);
 
         $std = $sm->get('foo');
-        $this->assertInstanceOf(stdClass::class, $std);
-        $this->assertEquals('baz', $std->bar);
+        self::assertInstanceOf(stdClass::class, $std);
+        self::assertEquals('baz', $std->bar);
     }
 
     public function testEventManagerInitializerCanBeReplaced(): void
@@ -154,7 +154,7 @@ class ServiceManagerConfigTest extends TestCase
         $config         = new ServiceManagerConfig();
         $config->configureServiceManager($serviceManager);
 
-        $this->assertTrue($serviceManager->has('ServiceManager'), 'Missing ServiceManager service!');
-        $this->assertSame($serviceManager, $serviceManager->get('ServiceManager'));
+        self::assertTrue($serviceManager->has('ServiceManager'), 'Missing ServiceManager service!');
+        self::assertSame($serviceManager, $serviceManager->get('ServiceManager'));
     }
 }

--- a/test/Service/ViewFeedStrategyFactoryTest.php
+++ b/test/Service/ViewFeedStrategyFactoryTest.php
@@ -25,6 +25,6 @@ class ViewFeedStrategyFactoryTest extends TestCase
     {
         $factory = new ViewFeedStrategyFactory();
         $result  = $factory($this->createContainer(), 'ViewFeedStrategy');
-        $this->assertInstanceOf(FeedStrategy::class, $result);
+        self::assertInstanceOf(FeedStrategy::class, $result);
     }
 }

--- a/test/Service/ViewHelperManagerFactoryTest.php
+++ b/test/Service/ViewHelperManagerFactoryTest.php
@@ -53,9 +53,9 @@ class ViewHelperManagerFactoryTest extends TestCase
     {
         $this->services->setService('config', $config);
         $manager = $this->factory->__invoke($this->services, 'doctype');
-        $this->assertInstanceof(HelperPluginManager::class, $manager);
+        self::assertInstanceof(HelperPluginManager::class, $manager);
         $doctype = $manager->get('doctype');
-        $this->assertInstanceof(Doctype::class, $doctype);
+        self::assertInstanceof(Doctype::class, $doctype);
     }
 
     public static function urlHelperNames(): array
@@ -97,8 +97,8 @@ class ViewHelperManagerFactoryTest extends TestCase
         $manager = $this->factory->__invoke($this->services, HelperPluginManager::class);
         $helper  = $manager->get($name);
 
-        $this->assertAttributeSame($routeMatch, 'routeMatch', $helper, 'Route match was not injected');
-        $this->assertAttributeSame($router, 'router', $helper, 'Router was not injected');
+        self::assertAttributeSame($routeMatch, 'routeMatch', $helper, 'Route match was not injected');
+        self::assertAttributeSame($router, 'router', $helper, 'Router was not injected');
     }
 
     public static function basePathConfiguration(): iterable
@@ -158,8 +158,8 @@ class ViewHelperManagerFactoryTest extends TestCase
 
         $plugins = $this->factory->__invoke($this->services, HelperPluginManager::class);
         $helper  = $plugins->get($name);
-        $this->assertInstanceof(BasePath::class, $helper);
-        $this->assertEquals($expected, $helper());
+        self::assertInstanceof(BasePath::class, $helper);
+        self::assertEquals($expected, $helper());
     }
 
     public static function doctypeHelperNames(): array
@@ -186,7 +186,7 @@ class ViewHelperManagerFactoryTest extends TestCase
 
         $plugins = $this->factory->__invoke($this->services, HelperPluginManager::class);
         $helper  = $plugins->get($name);
-        $this->assertInstanceof(Doctype::class, $helper);
-        $this->assertEquals('<!DOCTYPE html>', (string) $helper);
+        self::assertInstanceof(Doctype::class, $helper);
+        self::assertEquals('<!DOCTYPE html>', (string) $helper);
     }
 }

--- a/test/Service/ViewJsonStrategyFactoryTest.php
+++ b/test/Service/ViewJsonStrategyFactoryTest.php
@@ -25,6 +25,6 @@ class ViewJsonStrategyFactoryTest extends TestCase
     {
         $factory = new ViewJsonStrategyFactory();
         $result  = $factory($this->createContainer(), 'ViewJsonStrategy');
-        $this->assertInstanceOf(JsonStrategy::class, $result);
+        self::assertInstanceOf(JsonStrategy::class, $result);
     }
 }

--- a/test/Service/ViewManagerFactoryTest.php
+++ b/test/Service/ViewManagerFactoryTest.php
@@ -24,6 +24,6 @@ class ViewManagerFactoryTest extends TestCase
     {
         $factory = new ViewManagerFactory();
         $result  = $factory($this->createContainer(), 'ViewManager');
-        $this->assertInstanceOf(HttpViewManager::class, $result);
+        self::assertInstanceOf(HttpViewManager::class, $result);
     }
 }

--- a/test/Service/ViewPrefixPathStackResolverFactoryTest.php
+++ b/test/Service/ViewPrefixPathStackResolverFactoryTest.php
@@ -25,6 +25,6 @@ class ViewPrefixPathStackResolverFactoryTest extends TestCase
         $factory  = new ViewPrefixPathStackResolverFactory();
         $resolver = $factory($serviceLocator, 'ViewPrefixPathStackResolver');
 
-        $this->assertInstanceOf(PrefixPathStackResolver::class, $resolver);
+        self::assertInstanceOf(PrefixPathStackResolver::class, $resolver);
     }
 }

--- a/test/View/CreateViewModelListenerTest.php
+++ b/test/View/CreateViewModelListenerTest.php
@@ -37,8 +37,8 @@ class CreateViewModelListenerTest extends TestCase
         $this->listener->createViewModelFromArray($this->event);
 
         $test = $this->event->getResult();
-        $this->assertInstanceOf(ViewModel::class, $test);
-        $this->assertEquals($array, $test->getVariables());
+        self::assertInstanceOf(ViewModel::class, $test);
+        self::assertEquals($array, $test->getVariables());
     }
 
     public static function nonAssocArrayResults(): array
@@ -67,22 +67,22 @@ class CreateViewModelListenerTest extends TestCase
         $this->listener->createViewModelFromArray($this->event);
 
         $result = $this->event->getResult();
-        $this->assertEquals(gettype($test), gettype($result));
-        $this->assertEquals($test, $result);
+        self::assertEquals(gettype($test), gettype($result));
+        self::assertEquals($test, $result);
     }
 
     public function testAttachesListenersAtExpectedPriority(): void
     {
         $events = new EventManager();
         $this->listener->attach($events);
-        $this->assertListenerAtPriority(
+        self::assertListenerAtPriority(
             [$this->listener, 'createViewModelFromArray'],
             -80,
             MvcEvent::EVENT_DISPATCH,
             $events,
             'Did not find createViewModelFromArray listener in event list at expected priority'
         );
-        $this->assertListenerAtPriority(
+        self::assertListenerAtPriority(
             [$this->listener, 'createViewModelFromNull'],
             -80,
             MvcEvent::EVENT_DISPATCH,
@@ -96,11 +96,11 @@ class CreateViewModelListenerTest extends TestCase
         $events = new EventManager();
         $this->listener->attach($events);
         $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH, $events);
-        $this->assertEquals(2, count($listeners));
+        self::assertEquals(2, count($listeners));
 
         $this->listener->detach($events);
         $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH, $events);
-        $this->assertEquals(0, count($listeners));
+        self::assertEquals(0, count($listeners));
     }
 
     public function testViewModelCreatesViewModelWithEmptyArray(): void
@@ -108,7 +108,7 @@ class CreateViewModelListenerTest extends TestCase
         $this->event->setResult([]);
         $this->listener->createViewModelFromArray($this->event);
         $result = $this->event->getResult();
-        $this->assertInstanceOf(ViewModel::class, $result);
+        self::assertInstanceOf(ViewModel::class, $result);
     }
 
     public function testViewModelCreatesViewModelWithNullResult(): void
@@ -116,6 +116,6 @@ class CreateViewModelListenerTest extends TestCase
         $this->event->setResult(null);
         $this->listener->createViewModelFromNull($this->event);
         $result = $this->event->getResult();
-        $this->assertInstanceOf(ViewModel::class, $result);
+        self::assertInstanceOf(ViewModel::class, $result);
     }
 }

--- a/test/View/DefaultRendereringStrategyTest.php
+++ b/test/View/DefaultRendereringStrategyTest.php
@@ -57,7 +57,7 @@ class DefaultRendereringStrategyTest extends TestCase
         $events = [MvcEvent::EVENT_RENDER, MvcEvent::EVENT_RENDER_ERROR];
 
         foreach ($events as $event) {
-            $this->assertListenerAtPriority(
+            self::assertListenerAtPriority(
                 [$this->strategy, 'render'],
                 -10000,
                 $event,
@@ -72,11 +72,11 @@ class DefaultRendereringStrategyTest extends TestCase
         $events = new EventManager();
         $this->strategy->attach($events);
         $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_RENDER, $events);
-        $this->assertCount(1, $listeners);
+        self::assertCount(1, $listeners);
 
         $this->strategy->detach($events);
         $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_RENDER, $events);
-        $this->assertCount(0, $listeners);
+        self::assertCount(0, $listeners);
     }
 
     public function testWillRenderAlternateStrategyWhenSelected(): void
@@ -88,20 +88,20 @@ class DefaultRendereringStrategyTest extends TestCase
         $this->event->setResult($model);
 
         $result = $this->strategy->render($this->event);
-        $this->assertSame($this->response, $result);
+        self::assertSame($this->response, $result);
 
         $expected = sprintf('content (%s): %s', json_encode(['template' => 'content']), json_encode(['foo' => 'bar']));
     }
 
     public function testLayoutTemplateIsLayoutByDefault(): void
     {
-        $this->assertEquals('layout', $this->strategy->getLayoutTemplate());
+        self::assertEquals('layout', $this->strategy->getLayoutTemplate());
     }
 
     public function testLayoutTemplateIsMutable(): void
     {
         $this->strategy->setLayoutTemplate('alternate/layout');
-        $this->assertEquals('alternate/layout', $this->strategy->getLayoutTemplate());
+        self::assertEquals('alternate/layout', $this->strategy->getLayoutTemplate());
     }
 
     public function testBypassesRenderingIfResultIsAResponse(): void
@@ -114,7 +114,7 @@ class DefaultRendereringStrategyTest extends TestCase
         $this->event->setResult($this->response);
 
         $result = $this->strategy->render($this->event);
-        $this->assertSame($this->response, $result);
+        self::assertSame($this->response, $result);
     }
 
     public function testTriggersRenderErrorEventInCaseOfRenderingException(): void
@@ -162,9 +162,9 @@ class DefaultRendereringStrategyTest extends TestCase
 
         $this->strategy->render($this->event);
 
-        $this->assertTrue($test->flag);
-        $this->assertEquals(Application::ERROR_EXCEPTION, $test->error);
-        $this->assertInstanceOf('Exception', $test->exception);
-        $this->assertStringContainsString('script', $test->exception->getMessage());
+        self::assertTrue($test->flag);
+        self::assertEquals(Application::ERROR_EXCEPTION, $test->error);
+        self::assertInstanceOf('Exception', $test->exception);
+        self::assertStringContainsString('script', $test->exception->getMessage());
     }
 }

--- a/test/View/ExceptionStrategyTest.php
+++ b/test/View/ExceptionStrategyTest.php
@@ -29,24 +29,24 @@ class ExceptionStrategyTest extends TestCase
 
     public function testDisplayExceptionsIsDisabledByDefault(): void
     {
-        $this->assertFalse($this->strategy->displayExceptions());
+        self::assertFalse($this->strategy->displayExceptions());
     }
 
     public function testDisplayExceptionsFlagIsMutable(): void
     {
         $this->strategy->setDisplayExceptions(true);
-        $this->assertTrue($this->strategy->displayExceptions());
+        self::assertTrue($this->strategy->displayExceptions());
     }
 
     public function testExceptionTemplateHasASaneDefault(): void
     {
-        $this->assertEquals('error', $this->strategy->getExceptionTemplate());
+        self::assertEquals('error', $this->strategy->getExceptionTemplate());
     }
 
     public function testExceptionTemplateIsMutable(): void
     {
         $this->strategy->setExceptionTemplate('pages/error');
-        $this->assertEquals('pages/error', $this->strategy->getExceptionTemplate());
+        self::assertEquals('pages/error', $this->strategy->getExceptionTemplate());
     }
 
     public function test404ApplicationErrorsResultInNoOperations(): void
@@ -57,15 +57,15 @@ class ExceptionStrategyTest extends TestCase
             $this->strategy->prepareExceptionViewModel($event);
             $response = $event->getResponse();
             if (null !== $response) {
-                $this->assertNotEquals(500, $response->getStatusCode());
+                self::assertNotEquals(500, $response->getStatusCode());
             }
             $model = $event->getResult();
             if (null !== $model) {
                 $variables = $model->getVariables();
-                $this->assertArrayNotHasKey('message', $variables);
-                $this->assertArrayNotHasKey('exception', $variables);
-                $this->assertArrayNotHasKey('display_exceptions', $variables);
-                $this->assertNotEquals('error', $model->getTemplate());
+                self::assertArrayNotHasKey('message', $variables);
+                self::assertArrayNotHasKey('exception', $variables);
+                self::assertArrayNotHasKey('display_exceptions', $variables);
+                self::assertNotEquals('error', $model->getTemplate());
             }
         }
 
@@ -81,19 +81,19 @@ class ExceptionStrategyTest extends TestCase
         $this->strategy->prepareExceptionViewModel($event);
 
         $response = $event->getResponse();
-        $this->assertTrue($response->isServerError());
+        self::assertTrue($response->isServerError());
 
         $model = $event->getResult();
-        $this->assertInstanceOf(ViewModel::class, $model);
-        $this->assertEquals($this->strategy->getExceptionTemplate(), $model->getTemplate());
+        self::assertInstanceOf(ViewModel::class, $model);
+        self::assertEquals($this->strategy->getExceptionTemplate(), $model->getTemplate());
 
         $variables = $model->getVariables();
-        $this->assertArrayHasKey('message', $variables);
-        $this->assertStringContainsString('error occurred', $variables['message']);
-        $this->assertArrayHasKey('exception', $variables);
-        $this->assertSame($exception, $variables['exception']);
-        $this->assertArrayHasKey('display_exceptions', $variables);
-        $this->assertEquals($this->strategy->displayExceptions(), $variables['display_exceptions']);
+        self::assertArrayHasKey('message', $variables);
+        self::assertStringContainsString('error occurred', $variables['message']);
+        self::assertArrayHasKey('exception', $variables);
+        self::assertSame($exception, $variables['exception']);
+        self::assertArrayHasKey('display_exceptions', $variables);
+        self::assertEquals($this->strategy->displayExceptions(), $variables['display_exceptions']);
     }
 
     public function testCatchesUnknownErrorTypes(): void
@@ -105,7 +105,7 @@ class ExceptionStrategyTest extends TestCase
         $this->strategy->prepareExceptionViewModel($event);
 
         $response = $event->getResponse();
-        $this->assertTrue($response->isServerError());
+        self::assertTrue($response->isServerError());
     }
 
     public function testEmptyErrorInEventResultsInNoOperations(): void
@@ -114,15 +114,15 @@ class ExceptionStrategyTest extends TestCase
         $this->strategy->prepareExceptionViewModel($event);
         $response = $event->getResponse();
         if (null !== $response) {
-            $this->assertNotEquals(500, $response->getStatusCode());
+            self::assertNotEquals(500, $response->getStatusCode());
         }
         $model = $event->getResult();
         if (null !== $model) {
             $variables = $model->getVariables();
-            $this->assertArrayNotHasKey('message', $variables);
-            $this->assertArrayNotHasKey('exception', $variables);
-            $this->assertArrayNotHasKey('display_exceptions', $variables);
-            $this->assertNotEquals('error', $model->getTemplate());
+            self::assertArrayNotHasKey('message', $variables);
+            self::assertArrayNotHasKey('exception', $variables);
+            self::assertArrayNotHasKey('display_exceptions', $variables);
+            self::assertNotEquals('error', $model->getTemplate());
         }
 
         $this->addToAssertionCount(1);
@@ -136,7 +136,7 @@ class ExceptionStrategyTest extends TestCase
         $event->setResult($response);
         $event->setError('foobar');
 
-        $this->assertNull($this->strategy->prepareExceptionViewModel($event));
+        self::assertNull($this->strategy->prepareExceptionViewModel($event));
     }
 
     public function testAttachesListenerAtExpectedPriority(): void
@@ -144,7 +144,7 @@ class ExceptionStrategyTest extends TestCase
         $events = new EventManager();
         $this->strategy->attach($events);
 
-        $this->assertListenerAtPriority(
+        self::assertListenerAtPriority(
             [$this->strategy, 'prepareExceptionViewModel'],
             1,
             MvcEvent::EVENT_DISPATCH_ERROR,
@@ -157,10 +157,10 @@ class ExceptionStrategyTest extends TestCase
         $events = new EventManager();
         $this->strategy->attach($events);
         $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events);
-        $this->assertEquals(1, count($listeners));
+        self::assertEquals(1, count($listeners));
         $this->strategy->detach($events);
         $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events);
-        $this->assertEquals(0, count($listeners));
+        self::assertEquals(0, count($listeners));
     }
 
     public function testReuseResponseStatusCodeIfItExists(): void
@@ -172,15 +172,15 @@ class ExceptionStrategyTest extends TestCase
         $this->strategy->prepareExceptionViewModel($event);
         $response = $event->getResponse();
         if (null !== $response) {
-            $this->assertEquals(401, $response->getStatusCode());
+            self::assertEquals(401, $response->getStatusCode());
         }
         $model = $event->getResult();
         if (null !== $model) {
             $variables = $model->getVariables();
-            $this->assertArrayNotHasKey('message', $variables);
-            $this->assertArrayNotHasKey('exception', $variables);
-            $this->assertArrayNotHasKey('display_exceptions', $variables);
-            $this->assertNotEquals('error', $model->getTemplate());
+            self::assertArrayNotHasKey('message', $variables);
+            self::assertArrayNotHasKey('exception', $variables);
+            self::assertArrayNotHasKey('display_exceptions', $variables);
+            self::assertNotEquals('error', $model->getTemplate());
         }
     }
 }

--- a/test/View/InjectTemplateListenerTest.php
+++ b/test/View/InjectTemplateListenerTest.php
@@ -47,7 +47,7 @@ class InjectTemplateListenerTest extends TestCase
 
         $this->listener->injectTemplate($this->event);
 
-        $this->assertEquals('foo/somewhat/useful', $model->getTemplate());
+        self::assertEquals('foo/somewhat/useful', $model->getTemplate());
     }
 
     public function testUsesModuleAndControllerOnlyIfNoActionInRouteMatch(): void
@@ -59,7 +59,7 @@ class InjectTemplateListenerTest extends TestCase
 
         $this->listener->injectTemplate($this->event);
 
-        $this->assertEquals('foo/somewhat', $model->getTemplate());
+        self::assertEquals('foo/somewhat', $model->getTemplate());
     }
 
     public function testNormalizesLiteralControllerNameIfNoNamespaceSeparatorPresent(): void
@@ -71,7 +71,7 @@ class InjectTemplateListenerTest extends TestCase
 
         $this->listener->injectTemplate($this->event);
 
-        $this->assertEquals('somewhat', $model->getTemplate());
+        self::assertEquals('somewhat', $model->getTemplate());
     }
 
     public function testNormalizesNamesToLowercase(): void
@@ -84,13 +84,13 @@ class InjectTemplateListenerTest extends TestCase
 
         $this->listener->injectTemplate($this->event);
 
-        $this->assertEquals('somewhat.derived/some-uber-cool', $model->getTemplate());
+        self::assertEquals('somewhat.derived/some-uber-cool', $model->getTemplate());
     }
 
     public function testLackOfViewModelInResultBypassesTemplateInjection(): void
     {
-        $this->assertNull($this->listener->injectTemplate($this->event));
-        $this->assertNull($this->event->getResult());
+        self::assertNull($this->listener->injectTemplate($this->event));
+        self::assertNull($this->event->getResult());
     }
 
     public function testBypassesTemplateInjectionIfResultViewModelAlreadyHasATemplate(): void
@@ -104,7 +104,7 @@ class InjectTemplateListenerTest extends TestCase
 
         $this->listener->injectTemplate($this->event);
 
-        $this->assertEquals('custom', $model->getTemplate());
+        self::assertEquals('custom', $model->getTemplate());
     }
 
     public function testMapsSubNamespaceToSubDirectory(): void
@@ -116,7 +116,7 @@ class InjectTemplateListenerTest extends TestCase
 
         $this->listener->injectTemplate($this->event);
 
-        $this->assertEquals('laminas-test/mvc/test-asset/sample', $myViewModel->getTemplate());
+        self::assertEquals('laminas-test/mvc/test-asset/sample', $myViewModel->getTemplate());
     }
 
     public function testMapsSubNamespaceToSubDirectoryWithControllerFromRouteMatch(): void
@@ -132,7 +132,7 @@ class InjectTemplateListenerTest extends TestCase
         $this->event->setResult($model);
         $this->listener->injectTemplate($this->event);
 
-        $this->assertEquals('aj/sweet-apple-acres/reports/cider-sales/pinkie-pie-revenue', $model->getTemplate());
+        self::assertEquals('aj/sweet-apple-acres/reports/cider-sales/pinkie-pie-revenue', $model->getTemplate());
     }
 
     public function testMapsSubNamespaceToSubDirectoryWithControllerFromRouteMatchHavingSubNamespace(): void
@@ -148,7 +148,7 @@ class InjectTemplateListenerTest extends TestCase
         $this->event->setResult($model);
         $this->listener->injectTemplate($this->event);
 
-        $this->assertEquals('aj/sweet-apple-acres/reports/sub/cider-sales/pinkie-pie-revenue', $model->getTemplate());
+        self::assertEquals('aj/sweet-apple-acres/reports/sub/cider-sales/pinkie-pie-revenue', $model->getTemplate());
     }
 
     public function testMapsSubNamespaceToSubDirectoryWithControllerFromEventTarget(): void
@@ -166,7 +166,7 @@ class InjectTemplateListenerTest extends TestCase
         $this->event->setResult($myViewModel);
         $this->listener->injectTemplate($this->event);
 
-        $this->assertEquals('laminas-test/mvc/test-asset/sample/test', $myViewModel->getTemplate());
+        self::assertEquals('laminas-test/mvc/test-asset/sample/test', $myViewModel->getTemplate());
     }
 
     /**
@@ -194,7 +194,7 @@ class InjectTemplateListenerTest extends TestCase
         $this->event->setResult($myViewModel);
         $this->listener->injectTemplate($this->event);
 
-        $this->assertEquals($template1, $myViewModel->getTemplate());
+        self::assertEquals($template1, $myViewModel->getTemplate());
     }
 
     public function testControllerMatchedByMapIsInflected(): void
@@ -205,7 +205,7 @@ class InjectTemplateListenerTest extends TestCase
         $this->event->setResult($myViewModel);
         $this->listener->injectTemplate($this->event);
 
-        $this->assertEquals('mapped-ns/sub-ns/sample', $myViewModel->getTemplate());
+        self::assertEquals('mapped-ns/sub-ns/sample', $myViewModel->getTemplate());
 
         $this->listener->setControllerMap(['LaminasTest' => true]);
         $myViewModel  = new ViewModel();
@@ -215,7 +215,7 @@ class InjectTemplateListenerTest extends TestCase
 
         $this->listener->injectTemplate($this->event);
 
-        $this->assertEquals('laminas-test/mvc/test-asset/sample', $myViewModel->getTemplate());
+        self::assertEquals('laminas-test/mvc/test-asset/sample', $myViewModel->getTemplate());
     }
 
     public function testFullControllerNameMatchIsMapped(): void
@@ -224,7 +224,7 @@ class InjectTemplateListenerTest extends TestCase
             'Foo\Bar\Controller\IndexController' => 'string-value',
         ]);
         $template = $this->listener->mapController('Foo\Bar\Controller\IndexController');
-        $this->assertEquals('string-value', $template);
+        self::assertEquals('string-value', $template);
     }
 
     public function testOnlyFullNamespaceMatchIsMapped(): void
@@ -234,7 +234,7 @@ class InjectTemplateListenerTest extends TestCase
             'Foo\Bar' => 'foo-bar-matched',
         ]);
         $template = $this->listener->mapController('Foo\BarBaz\Controller\IndexController');
-        $this->assertEquals('foo-matched/bar-baz/index', $template);
+        self::assertEquals('foo-matched/bar-baz/index', $template);
     }
 
     public function testControllerMapMatchedPrefixReplacedByStringValue(): void
@@ -243,7 +243,7 @@ class InjectTemplateListenerTest extends TestCase
             'Foo\Bar' => 'string-value',
         ]);
         $template = $this->listener->mapController('Foo\Bar\Controller\IndexController');
-        $this->assertEquals('string-value/index', $template);
+        self::assertEquals('string-value/index', $template);
     }
 
     public function testUsingNamespaceRouteParameterGivesSameResultAsFullControllerParameter(): void
@@ -267,7 +267,7 @@ class InjectTemplateListenerTest extends TestCase
         $this->event->setResult($myViewModel);
         $this->listener->injectTemplate($this->event);
 
-        $this->assertEquals($template1, $myViewModel->getTemplate());
+        self::assertEquals($template1, $myViewModel->getTemplate());
     }
 
     public function testControllerMapOnlyFullNamespaceMatches(): void
@@ -277,7 +277,7 @@ class InjectTemplateListenerTest extends TestCase
             'Foo\Bar' => 'foo-bar-matched',
         ]);
         $template = $this->listener->mapController('Foo\BarBaz\Controller\IndexController');
-        $this->assertEquals('foo-matched/bar-baz/index', $template);
+        self::assertEquals('foo-matched/bar-baz/index', $template);
     }
 
     public function testControllerMapRuleSetToFalseIsIgnored(): void
@@ -287,7 +287,7 @@ class InjectTemplateListenerTest extends TestCase
             'Foo\Bar' => false,
         ]);
         $template = $this->listener->mapController('Foo\Bar\Controller\IndexController');
-        $this->assertEquals('foo-matched/bar/index', $template);
+        self::assertEquals('foo-matched/bar/index', $template);
     }
 
     public function testControllerMapMoreSpecificRuleMatchesFirst(): void
@@ -297,21 +297,21 @@ class InjectTemplateListenerTest extends TestCase
             'Foo\Bar' => 'bar/baz',
         ]);
         $template = $this->listener->mapController('Foo\Bar\Controller\IndexController');
-        $this->assertEquals('bar/baz/index', $template);
+        self::assertEquals('bar/baz/index', $template);
 
         $this->listener->setControllerMap([
             'Foo\Bar' => 'bar/baz',
             'Foo'     => true,
         ]);
         $template = $this->listener->mapController('Foo\Bar\Controller\IndexController');
-        $this->assertEquals('bar/baz/index', $template);
+        self::assertEquals('bar/baz/index', $template);
     }
 
     public function testAttachesListenerAtExpectedPriority(): void
     {
         $events = new EventManager();
         $this->listener->attach($events);
-        $this->assertListenerAtPriority(
+        self::assertListenerAtPriority(
             [$this->listener, 'injectTemplate'],
             -90,
             MvcEvent::EVENT_DISPATCH,
@@ -324,16 +324,16 @@ class InjectTemplateListenerTest extends TestCase
         $events = new EventManager();
         $this->listener->attach($events);
         $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH, $events);
-        $this->assertEquals(1, count($listeners));
+        self::assertEquals(1, count($listeners));
 
         $this->listener->detach($events);
         $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH, $events);
-        $this->assertEquals(0, count($listeners));
+        self::assertEquals(0, count($listeners));
     }
 
     public function testPrefersRouteMatchController(): void
     {
-        $this->assertFalse($this->listener->isPreferRouteMatchController());
+        self::assertFalse($this->listener->isPreferRouteMatchController());
         $this->listener->setPreferRouteMatchController(true);
         $this->routeMatch->setParam('controller', 'Some\Other\Service\Namespace\Controller\Sample');
         $myViewModel  = new ViewModel();
@@ -343,12 +343,12 @@ class InjectTemplateListenerTest extends TestCase
         $this->event->setResult($myViewModel);
         $this->listener->injectTemplate($this->event);
 
-        $this->assertEquals('some/other/service/namespace/sample', $myViewModel->getTemplate());
+        self::assertEquals('some/other/service/namespace/sample', $myViewModel->getTemplate());
     }
 
     public function testPrefersRouteMatchControllerWithRouteMatchAndControllerMap(): void
     {
-        $this->assertFalse($this->listener->isPreferRouteMatchController());
+        self::assertFalse($this->listener->isPreferRouteMatchController());
         $controllerMap = [
             'Some\Other\Service\Namespace\Controller\Sample' => 'another/sample',
         ];
@@ -370,6 +370,6 @@ class InjectTemplateListenerTest extends TestCase
         $this->event->setResult($myViewModel);
         $this->listener->injectTemplate($this->event);
 
-        $this->assertEquals('another/sample', $myViewModel->getTemplate());
+        self::assertEquals('another/sample', $myViewModel->getTemplate());
     }
 }

--- a/test/View/InjectViewModelListenerTest.php
+++ b/test/View/InjectViewModelListenerTest.php
@@ -37,7 +37,7 @@ class InjectViewModelListenerTest extends TestCase
         $this->event->setResult($childModel);
 
         $this->listener->injectViewModel($this->event);
-        $this->assertSame($childModel, $this->event->getViewModel());
+        self::assertSame($childModel, $this->event->getViewModel());
     }
 
     public function testAddsViewModelAsChildOfEventViewModelWhenChildIsNotTerminal(): void
@@ -47,35 +47,35 @@ class InjectViewModelListenerTest extends TestCase
 
         $this->listener->injectViewModel($this->event);
         $model = $this->event->getViewModel();
-        $this->assertNotSame($childModel, $model);
-        $this->assertTrue($model->hasChildren());
-        $this->assertEquals(1, count($model));
+        self::assertNotSame($childModel, $model);
+        self::assertTrue($model->hasChildren());
+        self::assertEquals(1, count($model));
         $child = false;
         foreach ($model as $child) {
             break;
         }
-        $this->assertSame($childModel, $child);
+        self::assertSame($childModel, $child);
     }
 
     public function testLackOfViewModelInResultBypassesViewModelInjection(): void
     {
-        $this->assertNull($this->listener->injectViewModel($this->event));
-        $this->assertNull($this->event->getResult());
-        $this->assertFalse($this->event->getViewModel()->hasChildren());
+        self::assertNull($this->listener->injectViewModel($this->event));
+        self::assertNull($this->event->getResult());
+        self::assertFalse($this->event->getViewModel()->hasChildren());
     }
 
     public function testAttachesListenersAtExpectedPriorities(): void
     {
         $events = new EventManager();
         $this->listener->attach($events);
-        $this->assertListenerAtPriority(
+        self::assertListenerAtPriority(
             [$this->listener, 'injectViewModel'],
             -100,
             MvcEvent::EVENT_DISPATCH,
             $events
         );
 
-        $this->assertListenerAtPriority(
+        self::assertListenerAtPriority(
             [$this->listener, 'injectViewModel'],
             -100,
             MvcEvent::EVENT_DISPATCH_ERROR,
@@ -89,14 +89,14 @@ class InjectViewModelListenerTest extends TestCase
         $this->listener->attach($events);
 
         $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH, $events);
-        $this->assertCount(1, $listeners);
+        self::assertCount(1, $listeners);
         $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events);
-        $this->assertCount(1, $listeners);
+        self::assertCount(1, $listeners);
 
         $this->listener->detach($events);
         $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH, $events);
-        $this->assertCount(0, $listeners);
+        self::assertCount(0, $listeners);
         $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events);
-        $this->assertCount(0, $listeners);
+        self::assertCount(0, $listeners);
     }
 }

--- a/test/View/RouteNotFoundStrategyTest.php
+++ b/test/View/RouteNotFoundStrategyTest.php
@@ -50,18 +50,18 @@ class RouteNotFoundStrategyTest extends TestCase
         $this->strategy->prepareNotFoundViewModel($event);
 
         $viewModel = $event->getResult();
-        $this->assertInstanceOf(ModelInterface::class, $viewModel);
+        self::assertInstanceOf(ModelInterface::class, $viewModel);
 
         $variables = $viewModel->getVariables();
         switch ($assertion) {
             case 'assertEquals':
                 // Testing if we returned a message in the result
-                $this->assertEquals('bar', $variables['message']);
+                self::assertEquals('bar', $variables['message']);
                 break;
             case 'assertTrue':
                 // Testing if no message was returned in the result; in that
                 // case, default message is used from strategy
-                $this->assertTrue(isset($variables['message']));
+                self::assertTrue(isset($variables['message']));
                 break;
         }
     }
@@ -80,7 +80,7 @@ class RouteNotFoundStrategyTest extends TestCase
             $response->setStatusCode(200);
             $event->setError($error);
             $this->strategy->detectNotFoundError($event);
-            $this->assertTrue($response->isNotFound(), 'Failed asserting against ' . $key);
+            self::assertTrue($response->isNotFound(), 'Failed asserting against ' . $key);
         }
     }
 
@@ -103,13 +103,13 @@ class RouteNotFoundStrategyTest extends TestCase
                 $this->strategy->detectNotFoundError($event);
                 $this->strategy->prepareNotFoundViewModel($event);
                 $viewModel = $event->getResult();
-                $this->assertInstanceOf(ModelInterface::class, $viewModel);
+                self::assertInstanceOf(ModelInterface::class, $viewModel);
                 $variables = $viewModel->getVariables();
                 if ($allow) {
-                    $this->assertTrue(isset($variables['reason']));
-                    $this->assertEquals($key, $variables['reason']);
+                    self::assertTrue(isset($variables['reason']));
+                    self::assertEquals($key, $variables['reason']);
                 } else {
-                    $this->assertFalse(isset($variables['reason']));
+                    self::assertFalse(isset($variables['reason']));
                 }
             }
         }
@@ -128,7 +128,7 @@ class RouteNotFoundStrategyTest extends TestCase
             $response->setStatusCode(200);
             $event->setError($error);
             $this->strategy->detectNotFoundError($event);
-            $this->assertFalse($response->isNotFound());
+            self::assertFalse($response->isNotFound());
         }
     }
 
@@ -142,9 +142,9 @@ class RouteNotFoundStrategyTest extends TestCase
         $this->strategy->prepareNotFoundViewModel($event);
         $model = $event->getResult();
         if ($model instanceof ViewModel) {
-            $this->assertNotEquals($this->strategy->getNotFoundTemplate(), $model->getTemplate());
+            self::assertNotEquals($this->strategy->getNotFoundTemplate(), $model->getTemplate());
             $variables = $model->getVariables();
-            $this->assertArrayNotHasKey('message', $variables);
+            self::assertArrayNotHasKey('message', $variables);
         }
 
         $this->addToAssertionCount(1);
@@ -160,9 +160,9 @@ class RouteNotFoundStrategyTest extends TestCase
         $this->strategy->prepareNotFoundViewModel($event);
         $model = $event->getResult();
         if ($model instanceof ViewModel) {
-            $this->assertNotEquals($this->strategy->getNotFoundTemplate(), $model->getTemplate());
+            self::assertNotEquals($this->strategy->getNotFoundTemplate(), $model->getTemplate());
             $variables = $model->getVariables();
-            $this->assertArrayNotHasKey('message', $variables);
+            self::assertArrayNotHasKey('message', $variables);
         }
 
         $this->addToAssertionCount(1);
@@ -177,10 +177,10 @@ class RouteNotFoundStrategyTest extends TestCase
 
         $this->strategy->prepareNotFoundViewModel($event);
         $model = $event->getResult();
-        $this->assertInstanceOf(ModelInterface::class, $model);
-        $this->assertEquals($this->strategy->getNotFoundTemplate(), $model->getTemplate());
+        self::assertInstanceOf(ModelInterface::class, $model);
+        self::assertEquals($this->strategy->getNotFoundTemplate(), $model->getTemplate());
         $variables = $model->getVariables();
-        $this->assertTrue(isset($variables['message']));
+        self::assertTrue(isset($variables['message']));
     }
 
     public function test404ResponsePrepares404ViewModelWithReasonWhenAllowed(): void
@@ -195,13 +195,13 @@ class RouteNotFoundStrategyTest extends TestCase
             $event->setResponse($response);
             $this->strategy->prepareNotFoundViewModel($event);
             $model = $event->getResult();
-            $this->assertInstanceOf(ModelInterface::class, $model);
+            self::assertInstanceOf(ModelInterface::class, $model);
             $variables = $model->getVariables();
             if ($allow) {
-                $this->assertTrue(isset($variables['reason']));
-                $this->assertEquals(Application::ERROR_CONTROLLER_CANNOT_DISPATCH, $variables['reason']);
+                self::assertTrue(isset($variables['reason']));
+                self::assertEquals(Application::ERROR_CONTROLLER_CANNOT_DISPATCH, $variables['reason']);
             } else {
-                $this->assertFalse(isset($variables['reason']));
+                self::assertFalse(isset($variables['reason']));
             }
         }
     }
@@ -220,14 +220,14 @@ class RouteNotFoundStrategyTest extends TestCase
             $event->setResponse($response);
             $this->strategy->prepareNotFoundViewModel($event);
             $model = $event->getResult();
-            $this->assertInstanceOf(ModelInterface::class, $model);
+            self::assertInstanceOf(ModelInterface::class, $model);
             $variables = $model->getVariables();
             if ($allow) {
-                $this->assertTrue($variables['display_exceptions']);
-                $this->assertTrue(isset($variables['exception']));
-                $this->assertSame($exception, $variables['exception']);
+                self::assertTrue($variables['display_exceptions']);
+                self::assertTrue(isset($variables['exception']));
+                self::assertSame($exception, $variables['exception']);
             } else {
-                $this->assertFalse(isset($variables['exception']));
+                self::assertFalse(isset($variables['exception']));
             }
         }
     }
@@ -249,16 +249,16 @@ class RouteNotFoundStrategyTest extends TestCase
                 $event->setResponse($response);
                 $this->strategy->prepareNotFoundViewModel($event);
                 $model = $event->getResult();
-                $this->assertInstanceOf(ModelInterface::class, $model);
+                self::assertInstanceOf(ModelInterface::class, $model);
                 $variables = $model->getVariables();
                 if ($allow) {
-                    $this->assertTrue(isset($variables['controller']));
-                    $this->assertEquals($controller, $variables['controller']);
-                    $this->assertTrue(isset($variables['controller_class']));
-                    $this->assertEquals($controllerClass, $variables['controller_class']);
+                    self::assertTrue(isset($variables['controller']));
+                    self::assertEquals($controller, $variables['controller']);
+                    self::assertTrue(isset($variables['controller_class']));
+                    self::assertEquals($controllerClass, $variables['controller_class']);
                 } else {
-                    $this->assertFalse(isset($variables['controller']));
-                    $this->assertFalse(isset($variables['controller_class']));
+                    self::assertFalse(isset($variables['controller']));
+                    self::assertFalse(isset($variables['controller_class']));
                 }
             }
         }
@@ -275,20 +275,20 @@ class RouteNotFoundStrategyTest extends TestCase
             $event->setError($error);
             $this->strategy->detectNotFoundError($event);
             $response = $event->getResponse();
-            $this->assertInstanceOf(Response::class, $response);
-            $this->assertTrue($response->isNotFound(), 'Failed asserting against ' . $key);
+            self::assertInstanceOf(Response::class, $response);
+            self::assertTrue($response->isNotFound(), 'Failed asserting against ' . $key);
         }
     }
 
     public function testNotFoundTemplateDefaultsToError(): void
     {
-        $this->assertEquals('error', $this->strategy->getNotFoundTemplate());
+        self::assertEquals('error', $this->strategy->getNotFoundTemplate());
     }
 
     public function testNotFoundTemplateIsMutable()
     {
         $this->strategy->setNotFoundTemplate('alternate/error');
-        $this->assertEquals('alternate/error', $this->strategy->getNotFoundTemplate());
+        self::assertEquals('alternate/error', $this->strategy->getNotFoundTemplate());
     }
 
     public function testAttachesListenersAtExpectedPriorities(): void
@@ -301,7 +301,7 @@ class RouteNotFoundStrategyTest extends TestCase
             MvcEvent::EVENT_DISPATCH_ERROR => 1,
         ];
         foreach ($evs as $event => $expectedPriority) {
-            $this->assertListenerAtPriority(
+            self::assertListenerAtPriority(
                 [$this->strategy, 'prepareNotFoundViewModel'],
                 $expectedPriority,
                 $event,
@@ -309,7 +309,7 @@ class RouteNotFoundStrategyTest extends TestCase
             );
         }
 
-        $this->assertListenerAtPriority(
+        self::assertListenerAtPriority(
             [$this->strategy, 'detectNotFoundError'],
             1,
             $event,
@@ -322,15 +322,15 @@ class RouteNotFoundStrategyTest extends TestCase
         $events = new EventManager();
         $this->strategy->attach($events);
         $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH, $events);
-        $this->assertCount(1, $listeners);
+        self::assertCount(1, $listeners);
         $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events);
-        $this->assertCount(2, $listeners);
+        self::assertCount(2, $listeners);
 
         $this->strategy->detach($events);
 
         $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH, $events);
-        $this->assertCount(0, $listeners);
+        self::assertCount(0, $listeners);
         $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events);
-        $this->assertCount(0, $listeners);
+        self::assertCount(0, $listeners);
     }
 }


### PR DESCRIPTION
### Description

This PR aims to upgrade `laminas/laminas-servicemanager` to `^4.1.0` version.  
Methods signatures inherithed from `Laminas\ServiceManager::AbstractPluginManager` are updated.

Every call to phpunit static "assert" methods are updated as well.